### PR TITLE
Adding options to each endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,126 +96,144 @@ With cache
     
 CacheId can be anything. If you want to cache / request you can use 'koa-request-id' 
 
+### Options
+
+Each SDK methods accepts an additional options object as the last argument.
+
+```
+{
+    rawResponse: true
+}
+```
+
+Supported option properties:
+
+* `rawResponse`: the SDK method returns not just the data from the response, but all the status codes as well
+
 ### Administrators
 
 #### List
 
-    suiteAPI.administrator.getAdministrators(customerId);
+    suiteAPI.administrator.getAdministrators(customerId, options);
 
 #### Get
 
-    suiteAPI.administrator.getAdministrator(customerId, adminId);
+    suiteAPI.administrator.getAdministrator(customerId, adminId, options);
 
 #### Get By Name
 
-    suiteAPI.administrator.getAdministratorByName(customerId, adminName);
+    suiteAPI.administrator.getAdministratorByName(customerId, adminName, options);
 
 #### Patch
 
-    suiteAPI.administrator.patchAdministrator(customerId, adminId, payload);
+    suiteAPI.administrator.patchAdministrator(customerId, adminId, payload, options);
 
 #### Create
 
-    suiteAPI.administrator.createAdministrator(customerId, payload);
+    suiteAPI.administrator.createAdministrator(customerId, payload, options);
 
 #### Delete
 
-    suiteAPI.administrator.deleteAdministrator(customerId, adminId, successorId);
+    suiteAPI.administrator.deleteAdministrator(customerId, adminId, successorId, options);
     
 #### Disable
 
-    suiteAPI.administrator.disableAdministrator(customerId, adminId);
+    suiteAPI.administrator.disableAdministrator(customerId, adminId, options);
     
 #### Enable
 
-    suiteAPI.administrator.enableAdministrator(customerId, adminId, additionalDataToModify);
+    suiteAPI.administrator.enableAdministrator(customerId, adminId, additionalDataToModify, options);
     
 #### Get Interface Languages
 
-    suiteAPI.administrator.getInterfaceLanguages(customerId);
+    suiteAPI.administrator.getInterfaceLanguages(customerId, options);
     
 #### Get Access Levels
 
-    suiteAPI.administrator.getAccessLevels(customerId);
+    suiteAPI.administrator.getAccessLevels(customerId, options);
     
 #### Promote to Superadmin
 
-    suiteAPI.administrator.promoteToSuperadmin(customerId, adminId, additionalDataToModify);
+    suiteAPI.administrator.promoteToSuperadmin(customerId, adminId, additionalDataToModify, options);
 
 #### Create Administrator
 
-    suiteAPI.administrator.createAdministrator(customerId, additionalDataToModify);
+    suiteAPI.administrator.createAdministrator(customerId, additionalDataToModify, options);
 
 #### Create Superadmin
 
-    suiteAPI.administrator.createSuperadmin(customerId, additionalDataToModify);
+    suiteAPI.administrator.createSuperadmin(customerId, additionalDataToModify, options);
     
 #### Invite Existing Administrator
 
-    suiteAPI.administrator.inviteExistingAdministrator(customerId, adminId, additionalDataToModify);
+    suiteAPI.administrator.inviteExistingAdministrator(customerId, adminId, additionalDataToModify, options);
     
 ### Contact
 
 #### Create
 
-    suiteAPI.contact.create(customerId, payload);
+    suiteAPI.contact.create(customerId, payload, options);
 
 ### Contact List
 
 #### Create
 
-    suiteAPI.contactList.create(customerId, name, contactIds);
+    suiteAPI.contactList.create(customerId, name, contactIds, options);
 
 #### List
 
-    suiteAPI.contactList.list(customerId, contactListId);
+    suiteAPI.contactList.list(customerId, contactListId, options);
 
 ### ExternalEvent
 
 #### Trigger
 
-    suiteAPI.externalEvent.trigger(customerId, eventId, payload);
+    suiteAPI.externalEvent.trigger(customerId, eventId, payload, options);
 
 ### Language
 
 #### Translate
 
-    suiteAPI.language.translate(customerId, languageId);
+    suiteAPI.language.translate(customerId, languageId, options);
 
 ### Settings
 
 #### Get
 
-    suiteAPI.settings.getSettings(customerId);
+    suiteAPI.settings.getSettings(customerId, options);
 
 #### Get Corporate Domains
 
-    suiteAPI.settings.getCorporateDomains(customerId);
+    suiteAPI.settings.getCorporateDomains(customerId, options);
 
 #### Set Corporate Domains
 
-    suiteAPI.settings.setCorporateDomains(customerId, corporateDomainsArray);
+    suiteAPI.settings.setCorporateDomains(customerId, corporateDomainsArray, options);
 
 ### Email
 
 #### Copy
 
-    suiteAPI.email.copy(customerId, emailId, payload);
+    suiteAPI.email.copy(customerId, emailId, payload, options);
 
 #### Update source
 
-    suiteAPI.email.updateSource(customerId, emailId, payload);
+    suiteAPI.email.updateSource(customerId, emailId, payload, options);
 
 #### Launch
 
-    suiteAPI.email.launch(customerId, emailId, schedule, timezone);
+    suiteAPI.email.launch(customerId, emailId, schedule, timezone, options);
+
+#### List
+
+    suiteAPI.email.list(customerId, options);
 
 ### Segment
 
 #### List contacts
 
-    suiteAPI.segment.listContacts(customerId, segmentId, offset, limit);
+    suiteAPI.segment.listContacts(customerId, segmentId, offset, limit, options);
 
 #### List contacts
 
-    suiteAPI.segment.listSegments(customerId);
+    suiteAPI.segment.listSegments(customerId, options);

--- a/api/endpoints/administrator/index.js
+++ b/api/endpoints/administrator/index.js
@@ -15,15 +15,15 @@ var Administrator = function(request) {
 
 Administrator.prototype = {
 
-  getAdministrators: function(customerId) {
+  getAdministrators: function(customerId, options) {
     logger.log('administrator_getAdministrators');
-    return this._request.get(customerId, '/administrator');
+    return this._request.get(customerId, '/administrator', options);
   },
 
 
-  getSuperadmin: function(customerId) {
+  getSuperadmin: function(customerId, options) {
     logger.log('administrator_getSuperadmin');
-    return this.getAdministrators(customerId).then(function(response) {
+    return this.getAdministrators(customerId, options).then(function(response) {
       var firstSuperadmin = new AdminList(response).getFirstSuperadministrator();
       if (firstSuperadmin) return firstSuperadmin;
 
@@ -32,9 +32,9 @@ Administrator.prototype = {
   },
 
 
-  getAdministrator: function(customerId, adminId) {
+  getAdministrator: function(customerId, adminId, options) {
     logger.log('administrator_getAdministrator');
-    return this.getAdministrators(customerId).then(function(response) {
+    return this.getAdministrators(customerId, options).then(function(response) {
       var firstAdmin = new AdminList(response).getFirstById(adminId);
       if (firstAdmin) return firstAdmin;
 
@@ -43,9 +43,9 @@ Administrator.prototype = {
   },
 
 
-  getAdministratorByName: function(customerId, adminName) {
+  getAdministratorByName: function(customerId, adminName, options) {
     logger.log('administrator_getAdministrator');
-    return this.getAdministrators(customerId).then(function(response) {
+    return this.getAdministrators(customerId, options).then(function(response) {
       var firstAdmin = new AdminList(response).getFirstByName(adminName);
       if (firstAdmin) return firstAdmin;
 
@@ -54,32 +54,32 @@ Administrator.prototype = {
   },
 
 
-  getInterfaceLanguages: function(customerId) {
+  getInterfaceLanguages: function(customerId, options) {
     logger.log('administrator_getInterfaceLanguages');
-    return this._request.get(customerId, '/administrator/getinterfacelanguages');
+    return this._request.get(customerId, '/administrator/getinterfacelanguages', options);
   },
 
 
-  getLanguages: function(customerId, language) {
+  getLanguages: function(customerId, language, options) {
     logger.log('administrator_getLanguages');
     if (!language) language = 'en';
-    return this._request.get(customerId, '/language/translate/' + language);
+    return this._request.get(customerId, '/language/translate/' + language, options);
   },
 
 
-  getAccessLevels: function(customerId) {
+  getAccessLevels: function(customerId, options) {
     logger.log('administrator_getAccess');
-    return this._request.get(customerId, '/administrator/getaccesslevels');
+    return this._request.get(customerId, '/administrator/getaccesslevels', options);
   },
 
 
-  patchAdministrator: function(customerId, adminId, payload) {
+  patchAdministrator: function(customerId, adminId, payload, options) {
     logger.log('administrator_patchAdministrator');
-    return this._request.post(customerId, '/administrator/' + adminId + '/patch', payload);
+    return this._request.post(customerId, '/administrator/' + adminId + '/patch', payload, options);
   },
 
 
-  createAdministrator: function(customerId, additionalDataToModify) {
+  createAdministrator: function(customerId, additionalDataToModify, options) {
     logger.log('admin_createAdmin');
     if (!additionalDataToModify) additionalDataToModify = {};
 
@@ -95,11 +95,11 @@ Administrator.prototype = {
       disabled: 1
     });
 
-    return this._request.post(customerId, '/administrator/', dataToSend);
+    return this._request.post(customerId, '/administrator/', dataToSend, options);
   },
 
 
-  inviteExistingAdministrator: function(customerId, adminId, additionalDataToModify) {
+  inviteExistingAdministrator: function(customerId, adminId, additionalDataToModify, options) {
     logger.log('admin_inviteExistingAdministrator');
     if (!additionalDataToModify) additionalDataToModify = {};
 
@@ -109,26 +109,26 @@ Administrator.prototype = {
       password: this._generatePassword()
     });
 
-    return this.patchAdministrator(customerId, adminId, dataToSend);
+    return this.patchAdministrator(customerId, adminId, dataToSend, options);
   },
 
 
-  createSuperadmin: function(customerId, additionalDataToModify) {
+  createSuperadmin: function(customerId, additionalDataToModify, options) {
     var data = _.extend({}, additionalDataToModify, { superadmin: 1 });
-    return this.createAdministrator(customerId, data);
+    return this.createAdministrator(customerId, data, options);
   },
 
 
-  promoteToSuperadmin: function(customerId, adminId, additionalDataToModify) {
+  promoteToSuperadmin: function(customerId, adminId, additionalDataToModify, options) {
     var data = _.extend({}, additionalDataToModify, {
       superadmin: 1,
       access_level: 0
     });
-    return this.inviteExistingAdministrator(customerId, adminId, data);
+    return this.inviteExistingAdministrator(customerId, adminId, data, options);
   },
 
 
-  enable: function(customerId, adminId, additionalDataToModify) {
+  enable: function(customerId, adminId, additionalDataToModify, options) {
     logger.log('admin_enable');
     if (!additionalDataToModify) additionalDataToModify = {};
     var dataToSend = _.extend({}, additionalDataToModify, {
@@ -136,28 +136,28 @@ Administrator.prototype = {
       last_verification_action_date: dateHelper.getCurrentDate()
     });
 
-    return this.patchAdministrator(customerId, adminId, dataToSend);
+    return this.patchAdministrator(customerId, adminId, dataToSend, options);
   },
 
 
-  disableAdministrator: function(customerId, adminId) {
+  disableAdministrator: function(customerId, adminId, options) {
     logger.log('admin_disable');
 
     return this.patchAdministrator(customerId, adminId, {
       disabled: 1,
       last_verification_action_date: dateHelper.getCurrentDate()
-    });
+    }, options);
   },
 
 
-  deleteAdministrator: function(customerId, adminId, successorId) {
+  deleteAdministrator: function(customerId, adminId, successorId, options) {
     logger.log('admin_delete');
     var payload = {
       administratorId: adminId,
       successor_administrator_id: successorId
     };
 
-    return this._request.post(customerId, '/administrator/' + adminId + '/delete', payload);
+    return this._request.post(customerId, '/administrator/' + adminId + '/delete', payload, options);
   },
 
 

--- a/api/endpoints/contact/index.js
+++ b/api/endpoints/contact/index.js
@@ -8,9 +8,9 @@ var Contact = function(request) {
 
 Contact.prototype = {
 
-  create: function(customerId, payload) {
+  create: function(customerId, payload, options) {
     logger.log('contact_create');
-    return this._request.post(customerId, '/contact', payload);
+    return this._request.post(customerId, '/contact', payload, options);
   }
 
 };

--- a/api/endpoints/contactlist/index.js
+++ b/api/endpoints/contactlist/index.js
@@ -7,20 +7,20 @@ var ContactList = function (request) {
   this._request = request;
 };
 
-ContactList.prototype.create = function (customerId, name, contactIds) {
+ContactList.prototype.create = function (customerId, name, contactIds, options) {
   var url = '/contactlist';
   logger.log('contactlist_create');
   return this._request.post(customerId, url, {
     key_id: 'id',
     name: name,
     external_ids: contactIds
-  });
+  }, options);
 };
 
-ContactList.prototype.list = function (customerId, contactListId) {
+ContactList.prototype.list = function (customerId, contactListId, options) {
   var url = util.format('/contactlist/%s', contactListId);
   logger.log('contactlist_list');
-  return this._request.get(customerId, url);
+  return this._request.get(customerId, url, options);
 };
 
 ContactList.create = function (request) {

--- a/api/endpoints/email/index.js
+++ b/api/endpoints/email/index.js
@@ -7,27 +7,27 @@ var Email = function (request) {
   this._request = request;
 };
 
-Email.prototype.copy = function (customerId, emailId, payload) {
+Email.prototype.copy = function (customerId, emailId, payload, options) {
   logger.log('email_copy');
-  return this._request.post(customerId, util.format('/email/%s/copy', emailId), payload);
+  return this._request.post(customerId, util.format('/email/%s/copy', emailId), payload, options);
 };
 
-Email.prototype.updateSource = function (customerId, emailId, payload) {
+Email.prototype.updateSource = function (customerId, emailId, payload, options) {
   logger.log('email_update_source');
-  return this._request.post(customerId, util.format('/email/%s/updatesource', emailId), payload);
+  return this._request.post(customerId, util.format('/email/%s/updatesource', emailId), payload, options);
 };
 
-Email.prototype.list = function (customerId) {
+Email.prototype.list = function (customerId, options) {
   logger.log('email_list');
-  return this._request.get(customerId, '/email');
+  return this._request.get(customerId, '/email', options);
 };
 
-Email.prototype.launch = function (customerId, emailId, schedule, timezone) {
+Email.prototype.launch = function (customerId, emailId, schedule, timezone, options) {
   logger.log('email_launch');
   return this._request.post(customerId, util.format('/email/%s/launch', emailId), {
     schedule: schedule,
     timezone: timezone
-  });
+  }, options);
 };
 
 Email.create = function (request) {

--- a/api/endpoints/externalevent/index.js
+++ b/api/endpoints/externalevent/index.js
@@ -8,9 +8,9 @@ var ExternalEvent = function(request) {
 
 ExternalEvent.prototype = {
 
-  trigger: function(customerId, eventId, payload) {
+  trigger: function(customerId, eventId, payload, options) {
     logger.log('externalevent_trigger');
-    return this._request.post(customerId, '/event/' + eventId + '/trigger', payload);
+    return this._request.post(customerId, '/event/' + eventId + '/trigger', payload, options);
   }
 
 };

--- a/api/endpoints/language/index.js
+++ b/api/endpoints/language/index.js
@@ -8,10 +8,10 @@ var Language = function(request) {
 
 Language.prototype = {
 
-  translate: function(customerId, language) {
+  translate: function(customerId, language, options) {
     logger.log('language_translate');
     var languagePostfix = language ? '/' + language : '';
-    return this._request.get(customerId, '/language/translate' + languagePostfix);
+    return this._request.get(customerId, '/language/translate' + languagePostfix, options);
   }
 
 };

--- a/api/endpoints/segment/index.js
+++ b/api/endpoints/segment/index.js
@@ -10,18 +10,18 @@ var Segment = function (request) {
   this._request = request;
 };
 
-Segment.prototype.listContacts = function (customerId, segmentId, offset, limit) {
+Segment.prototype.listContacts = function (customerId, segmentId, offset, limit, options) {
   offset = offset || OFFSET;
   limit = limit || LIMIT;
   var url = util.format('/filter/%s/contacts/limit=%s&offset=%s', segmentId, limit, offset);
   logger.log('segment_list_contacts');
-  return this._request.get(customerId, url);
+  return this._request.get(customerId, url, options);
 };
 
-Segment.prototype.listSegments = function (customerId) {
+Segment.prototype.listSegments = function (customerId, options) {
   var url = '/filter';
   logger.log('segment_list');
-  return this._request.get(customerId, url);
+  return this._request.get(customerId, url, options);
 };
 
 Segment.create = function (request) {

--- a/api/endpoints/settings/index.js
+++ b/api/endpoints/settings/index.js
@@ -9,21 +9,21 @@ var Settings = function (request) {
 
 Settings.prototype = {
 
-  getSettings: function(customerId) {
+  getSettings: function(customerId, options) {
     logger.log('settings_getSettings');
-    return this._request.get(customerId, '/settings');
+    return this._request.get(customerId, '/settings', options);
   },
 
 
-  getCorporateDomains: function (customerId) {
+  getCorporateDomains: function (customerId, options) {
     logger.log('settings_get-corporate-domains');
-    return this._request.get(customerId, '/settings/corporatedomain');
+    return this._request.get(customerId, '/settings/corporatedomain', options);
   },
 
 
-  setCorporateDomains: function (customerId, domains) {
+  setCorporateDomains: function (customerId, domains, options) {
     logger.log('settings_set-corporate-domains');
-    return this._request.put(customerId, '/settings/corporatedomain', { domains: domains });
+    return this._request.put(customerId, '/settings/corporatedomain', { domains: domains }, options);
   }
 
 };

--- a/api/index.js
+++ b/api/index.js
@@ -54,6 +54,7 @@ SuiteAPI.prototype = {
 
   _createInternalApiRequest: function(options) {
     var requestOptions = SuiteRequestOptions.createForInternalApi(options.environment, options.rejectUnauthorized);
+    console.log(options)
     var suiteRequest = SuiteRequest.create(options.apiKey, options.apiSecret, requestOptions);
     return InternalApiRequest.create(suiteRequest);
   },

--- a/api/index.js
+++ b/api/index.js
@@ -54,7 +54,6 @@ SuiteAPI.prototype = {
 
   _createInternalApiRequest: function(options) {
     var requestOptions = SuiteRequestOptions.createForInternalApi(options.environment, options.rejectUnauthorized);
-    console.log(options)
     var suiteRequest = SuiteRequest.create(options.apiKey, options.apiSecret, requestOptions);
     return InternalApiRequest.create(suiteRequest);
   },

--- a/lib/api-request/index.js
+++ b/lib/api-request/index.js
@@ -15,9 +15,11 @@ var ApiRequest = function(suiteRequest) {
 
 ApiRequest.prototype = {
 
-  get: function(url) {
+  get: function(url, options) {
     var response;
     var cacheKey = this._getCacheKey('get', url);
+
+    options = options || {};
 
     if (this._cacheId) {
       response = cache.get(cacheKey);
@@ -32,26 +34,42 @@ ApiRequest.prototype = {
           cache.set(cacheKey, returnValue.data);
         }
 
+        if (options.rawResponse) {
+          return returnValue;
+        }
+
         return returnValue.data;
       }.bind(this));
   },
 
 
-  post: function(url, data) {
+  post: function(url, data, options) {
+    options = options || {};
     logger.log('post', _.extend({ destinationEndpoint: url }, data));
     return this._suiteRequest
       .post(url, data)
       .then(function(returnValue) {
+
+        if (options.rawResponse) {
+          return returnValue;
+        }
+
         return returnValue.data;
       });
   },
 
 
-  put: function(url, data) {
+  put: function(url, data, options) {
+    options = options || {};
     logger.log('put', _.extend({ destinationEndpoint: url }, data));
     return this._suiteRequest
       .put(url, data)
       .then(function(returnValue) {
+
+        if (options.rawResponse) {
+          return returnValue;
+        }
+
         return returnValue.data;
       });
   },

--- a/lib/api-request/index.js
+++ b/lib/api-request/index.js
@@ -30,6 +30,7 @@ ApiRequest.prototype = {
     return this._suiteRequest
       .get(url)
       .then(function(returnValue) {
+
         if (this._cacheId) {
           cache.set(cacheKey, returnValue.data);
         }

--- a/lib/api-request/index.spec.js
+++ b/lib/api-request/index.spec.js
@@ -33,7 +33,7 @@ describe('ApiRequest', function () {
     });
 
 
-    describe.only('with options', function () {
+    describe('with options', function () {
 
       it ('returns with the full response', function (done) {
         var promiseRespond = {
@@ -63,7 +63,7 @@ describe('ApiRequest', function () {
         }).then(done);
       });
     });
-    
+
     describe('with caching enabled', function() {
       var firstResponse, secondResponse;
 

--- a/lib/api-request/index.spec.js
+++ b/lib/api-request/index.spec.js
@@ -5,18 +5,22 @@ var sinon = require('sinon');
 var ApiRequest = require('./');
 
 
-describe('ApiRequest', function () {
+describe.only('ApiRequest', function () {
 
   describe('#get', function() {
 
     it('should call suite request\'s get', function(done) {
-      var promiseRespond = { dummyData: 12 };
+      var promiseRespond = {
+        data: {
+          dummyData: 12
+        }
+      };
       var suiteServiceRequest = getSuiteRequestResolvesWith(promiseRespond);
       var request = new ApiRequest(suiteServiceRequest);
 
       request.get('/customers').then(function(returnValue) {
         expect(suiteServiceRequest.get).to.have.been.calledWith('/customers');
-        expect(returnValue).to.eql(promiseRespond);
+        expect(returnValue).to.eql(promiseRespond.data);
       }).then(done);
     });
 
@@ -35,7 +39,7 @@ describe('ApiRequest', function () {
 
     describe('with options', function () {
 
-      it ('returns with the full response', function (done) {
+      it('returns with the full response', function (done) {
         var promiseRespond = {
           data: [1, 2, 3],
           replyCode: 10001
@@ -68,8 +72,8 @@ describe('ApiRequest', function () {
       var firstResponse, secondResponse;
 
       beforeEach(function() {
-        firstResponse = { dummyData: 12 };
-        secondResponse = { someNewData: 1 };
+        firstResponse = { data: {dummyData: 12} };
+        secondResponse = { data: {someNewData: 1} };
       });
 
       it('should return cached result after the first request', function(done) {
@@ -78,11 +82,11 @@ describe('ApiRequest', function () {
         request.setCache('someCacheId');
 
         request.get('/administrator').then(function(returnValue) {
-          expect(returnValue).to.eql(firstResponse);
+          expect(returnValue).to.eql(firstResponse.data);
           suiteServiceRequest.get = sinon.stub().returns(getPromiseResolvesWith(secondResponse));
 
           request.get('/administrator').then(function(returnValue) {
-            expect(returnValue).to.eql(firstResponse);
+            expect(returnValue).to.eql(firstResponse.data);
           }).then(done);
         });
       });
@@ -96,11 +100,11 @@ describe('ApiRequest', function () {
         request2.setCache('someCacheId');
 
         request1.get('/administrator').then(function(returnValue) {
-          expect(returnValue).to.eql(firstResponse);
+          expect(returnValue).to.eql(firstResponse.data);
           suiteServiceRequest.get = sinon.stub().returns(getPromiseResolvesWith(secondResponse));
 
           request2.get('/administrator').then(function(returnValue) {
-            expect(returnValue).to.eql(firstResponse);
+            expect(returnValue).to.eql(firstResponse.data);
           }).then(done);
         });
       });
@@ -114,17 +118,14 @@ describe('ApiRequest', function () {
         request2.setCache('someCacheId2');
 
         request1.get('/administrator').then(function(returnValue) {
-          expect(returnValue).to.eql(firstResponse);
+          expect(returnValue).to.eql(firstResponse.data);
           suiteServiceRequest.get = sinon.stub().returns(getPromiseResolvesWith(secondResponse));
 
           request2.get('/administrator').then(function(returnValue) {
-            expect(returnValue).to.eql(secondResponse);
+            expect(returnValue).to.eql(secondResponse.data);
           }).then(done);
         });
       });
-
-
-
 
     });
   });
@@ -133,14 +134,14 @@ describe('ApiRequest', function () {
   describe('#post', function() {
 
     it('should call suite request\'s post', function(done) {
-      var promiseRespond = { dummyData: 12 };
+      var promiseRespond = { data: {dummyData: 12} };
       var sendData = { yo: 5 };
       var suiteServiceRequest = getSuiteRequestResolvesWith(promiseRespond);
       var request = new ApiRequest(suiteServiceRequest);
 
       request.post('/administrator', sendData).then(function(returnValue) {
         expect(suiteServiceRequest.post).to.have.been.calledWith('/administrator', sendData);
-        expect(returnValue).to.eql(promiseRespond);
+        expect(returnValue).to.eql(promiseRespond.data);
       }).then(done);
     });
 
@@ -153,7 +154,7 @@ describe('ApiRequest', function () {
       request.post('/administrator', {}).catch(function(error) {
         expect(error).to.equal(promiseError);
         done();
-      })
+      });
     });
 
   });
@@ -162,14 +163,14 @@ describe('ApiRequest', function () {
   describe('#put', function() {
 
     it('should call suite request\'s put', function(done) {
-      var promiseRespond = { dummyData: 12 };
+      var promiseRespond = { data: {dummyData: 12} };
       var sendData = { yo: 5 };
       var suiteServiceRequest = getSuiteRequestResolvesWith(promiseRespond);
       var request = new ApiRequest(suiteServiceRequest);
 
       request.put('/administrator', sendData).then(function(returnValue) {
         expect(suiteServiceRequest.put).to.have.been.calledWith('/administrator', sendData);
-        expect(returnValue).to.eql(promiseRespond);
+        expect(returnValue).to.eql(promiseRespond.data);
       }).then(done);
     });
 
@@ -182,7 +183,7 @@ describe('ApiRequest', function () {
       request.put('/administrator', {}).catch(function(error) {
         expect(error).to.equal(promiseError);
         done();
-      })
+      });
     });
 
   });
@@ -210,7 +211,7 @@ describe('ApiRequest', function () {
 
   function getPromiseResolvesWith(respObj) {
     return new Promise(function(resolve) {
-      resolve({ data: respObj });
+      resolve(respObj);
     });
   }
 

--- a/lib/api-request/index.spec.js
+++ b/lib/api-request/index.spec.js
@@ -5,7 +5,7 @@ var sinon = require('sinon');
 var ApiRequest = require('./');
 
 
-describe.only('ApiRequest', function () {
+describe('ApiRequest', function () {
 
   describe('#get', function() {
 

--- a/lib/api-request/index.spec.js
+++ b/lib/api-request/index.spec.js
@@ -33,7 +33,37 @@ describe('ApiRequest', function () {
     });
 
 
+    describe.only('with options', function () {
 
+      it ('returns with the full response', function (done) {
+        var promiseRespond = {
+          data: [1, 2, 3],
+          replyCode: 10001
+        };
+        var suiteServiceRequest = getSuiteRequestResolvesWith(promiseRespond);
+        var request = new ApiRequest(suiteServiceRequest);
+
+        request.get('/customers', {rawResponse: true}).then(function(returnValue) {
+          expect(suiteServiceRequest.get).to.have.been.calledWith('/customers');
+          expect(returnValue).to.eql(promiseRespond);
+        }).then(done);
+      });
+
+      it('returns with the data only', function (done) {
+        var promiseRespond = {
+          data: [1, 2, 3],
+          replyCode: 10001
+        };
+        var suiteServiceRequest = getSuiteRequestResolvesWith(promiseRespond);
+        var request = new ApiRequest(suiteServiceRequest);
+
+        request.get('/customers').then(function(returnValue) {
+          expect(suiteServiceRequest.get).to.have.been.calledWith('/customers');
+          expect(returnValue).to.eql(promiseRespond.data);
+        }).then(done);
+      });
+    });
+    
     describe('with caching enabled', function() {
       var firstResponse, secondResponse;
 

--- a/lib/internal-api-request/index.js
+++ b/lib/internal-api-request/index.js
@@ -12,21 +12,21 @@ util.inherits(InternalApiRequest, Request);
 
 _.extend(InternalApiRequest.prototype, {
 
-  get: function (customerId, url) {
+  get: function (customerId, url, options) {
     var completeUrl = this._assembleUrl(customerId, url);
-    return Request.prototype.get.call(this, completeUrl).then(this._extractData);
+    return Request.prototype.get.call(this, completeUrl, options).then(this._extractData);
   },
 
 
-  post: function (customerId, url, data) {
+  post: function (customerId, url, data, options) {
     var completeUrl = this._assembleUrl(customerId, url);
-    return Request.prototype.post.call(this, completeUrl, data).then(this._extractData);
+    return Request.prototype.post.call(this, completeUrl, data, options).then(this._extractData);
   },
 
 
-  put: function (customerId, url, data) {
+  put: function (customerId, url, data, options) {
     var completeUrl = this._assembleUrl(customerId, url);
-    return Request.prototype.put.call(this, completeUrl, data).then(this._extractData);
+    return Request.prototype.put.call(this, completeUrl, data, options).then(this._extractData);
   },
 
 


### PR DESCRIPTION
This feature enables us to get the raw request, not just the data. The options field is optional.

#### Example

```
var suiteAPI = SuiteAPI.create();
suiteAPI.segment.listContacts(Number, Number, Number, Number, {rawResponse: true}).then(function (data) {
  console.log(data);
}).catch(function (err) {
  console.log(err);
});

```