### PR TITLE
Keeping up with escher-suiteapi-js and Suite API

### DIFF
--- a/api/endpoints/email/index.js
+++ b/api/endpoints/email/index.js
@@ -27,6 +27,11 @@ Email.prototype.get = function(customerId, emailId, options) {
   return this._request.get(customerId, util.format('/email/%s', emailId), options);
 };
 
+Email.prototype.patch = function(customerId, emailId, payload, options) {
+  logger.log('email_get');
+  return this._request.post(customerId, util.format('/email/%s/patch', emailId), payload, options);
+};
+
 Email.prototype.launch = function(customerId, emailId, schedule, timezone, options) {
   logger.log('email_launch');
   return this._request.post(customerId, util.format('/email/%s/launch', emailId), {

--- a/api/endpoints/email/index.js
+++ b/api/endpoints/email/index.js
@@ -22,6 +22,11 @@ Email.prototype.list = function(customerId, options) {
   return this._request.get(customerId, '/email', options);
 };
 
+Email.prototype.get = function(customerId, emailId, options) {
+  logger.log('email_get');
+  return this._request.get(customerId, util.format('/email/%s', emailId), options);
+};
+
 Email.prototype.launch = function(customerId, emailId, schedule, timezone, options) {
   logger.log('email_launch');
   return this._request.post(customerId, util.format('/email/%s/launch', emailId), {

--- a/api/endpoints/email/index.spec.js
+++ b/api/endpoints/email/index.spec.js
@@ -10,6 +10,13 @@ describe('Suite Email', function() {
     list: {
       method: 'get',
       expectedUrl: '/email'
+    },
+    get: {
+      method: 'get',
+      expectedUrl: '/email/32',
+      arguments: [
+        32
+      ]
     }
   };
 
@@ -45,6 +52,35 @@ describe('Suite Email', function() {
 
     api.updateSource(0, 32, {
       contactlistId: '3'
+    });
+
+  });
+
+  it('loads an existing email', function() {
+
+    var api = EmailAPI.create({
+      get: function(customerId, url, options) {
+        expect(url).to.equal('/email/32');
+      }
+    });
+
+    api.get(0, 32);
+
+  });
+
+  it('updates data of an existing email', function() {
+
+    var api = EmailAPI.create({
+      post: function(customerId, url, payload) {
+        expect(url).to.equal('/email/32/patch');
+        expect(payload).to.eql({
+          subject: 'lorem ipsum'
+        });
+      }
+    });
+
+    api.patch(0, 32, {
+      subject: 'lorem ipsum'
     });
 
   });

--- a/api/index.js
+++ b/api/index.js
@@ -54,14 +54,14 @@ SuiteAPI.prototype = {
 
 
   _createInternalApiRequest: function(options) {
-    var requestOptions = SuiteRequestOptions.createForInternalApi(options.environment, options.rejectUnauthorized);
+    var requestOptions = SuiteRequestOptions.createForInternalApi(options);
     var suiteRequest = SuiteRequest.create(options.apiKey, options.apiSecret, requestOptions);
     return InternalApiRequest.create(suiteRequest);
   },
 
 
   _createServiceApiRequest: function(options) {
-    var requestOptions = SuiteRequestOptions.createForServiceApi(options.environment, options.rejectUnauthorized);
+    var requestOptions = SuiteRequestOptions.createForServiceApi(options);
     var suiteRequest = SuiteRequest.create(options.apiKey, options.apiSecret, requestOptions);
     return ApiRequest.create(suiteRequest);
   },

--- a/api/index.spec.js
+++ b/api/index.spec.js
@@ -38,12 +38,17 @@ describe('SuiteApi', function() {
 
 
     it('should return a new instance of an API with the given environment and key data', function() {
+      var expectedArguments = {
+        environment: 'environment',
+        rejectUnauthorized: true
+      };
+
       stubRequestCreation();
       SuiteAPI.create({ environment: 'environment', apiKey: 'apiKey', apiSecret: 'apiSecret', rejectUnauthorized: true });
       expect(SuiteRequest.create).to.have.been.calledWith('apiKey', 'apiSecret', 'SuiteRequestOptionsStub');
       expect(SuiteRequest.create).to.have.been.calledWith('apiKey', 'apiSecret', 'SuiteServiceRequestOptionsStub');
-      expect(SuiteRequestOptions.createForInternalApi).to.have.been.calledWith('environment', true);
-      expect(SuiteRequestOptions.createForServiceApi).to.have.been.calledWith('environment', true);
+      expect(SuiteRequestOptions.createForInternalApi).to.have.been.calledWithMatch(expectedArguments);
+      expect(SuiteRequestOptions.createForServiceApi).to.have.been.calledWithMatch(expectedArguments);
     });
 
 
@@ -86,6 +91,11 @@ describe('SuiteApi', function() {
 
 
       it('should return a new instance with configuration from env variables', function() {
+        var expectedArguments = {
+          environment: 'environmentFromEnv',
+          rejectUnauthorized: false
+        };
+
         process.env.SUITE_API_ENVIRONMENT = 'environmentFromEnv';
         process.env.SUITE_API_KEY = 'apiKeyFromEnv';
         process.env.SUITE_API_SECRET = 'apiSecretFromEnv';
@@ -97,8 +107,8 @@ describe('SuiteApi', function() {
 
         expect(SuiteRequest.create).to.have.been.calledWith('apiKeyFromEnv', 'apiSecretFromEnv', 'SuiteRequestOptionsStub');
         expect(SuiteRequest.create).to.have.been.calledWith('apiKeyFromEnv', 'apiSecretFromEnv', 'SuiteServiceRequestOptionsStub');
-        expect(SuiteRequestOptions.createForInternalApi).to.have.been.calledWith('environmentFromEnv', false);
-        expect(SuiteRequestOptions.createForServiceApi).to.have.been.calledWith('environmentFromEnv', false);
+        expect(SuiteRequestOptions.createForInternalApi).to.have.been.calledWithMatch(expectedArguments);
+        expect(SuiteRequestOptions.createForServiceApi).to.have.been.calledWithMatch(expectedArguments);
       });
 
     });
@@ -106,6 +116,11 @@ describe('SuiteApi', function() {
     describe('environment is not provided from any source', function() {
 
       it('should return a new instance with API proxy', function() {
+        var expectedArguments = {
+          environment: 'api.emarsys.net',
+          rejectUnauthorized: true
+        };
+
         process.env.SUITE_API_KEY = 'apiKeyFromEnv';
         process.env.SUITE_API_SECRET = 'apiSecretFromEnv';
 
@@ -115,8 +130,8 @@ describe('SuiteApi', function() {
 
         expect(SuiteRequest.create).to.have.been.calledWith('apiKeyFromEnv', 'apiSecretFromEnv', 'SuiteRequestOptionsStub');
         expect(SuiteRequest.create).to.have.been.calledWith('apiKeyFromEnv', 'apiSecretFromEnv', 'SuiteServiceRequestOptionsStub');
-        expect(SuiteRequestOptions.createForInternalApi).to.have.been.calledWith('api.emarsys.net', true);
-        expect(SuiteRequestOptions.createForServiceApi).to.have.been.calledWith('api.emarsys.net', true);
+        expect(SuiteRequestOptions.createForInternalApi).to.have.been.calledWithMatch(expectedArguments);
+        expect(SuiteRequestOptions.createForServiceApi).to.have.been.calledWithMatch(expectedArguments);
       });
 
     });
@@ -133,11 +148,19 @@ describe('SuiteApi', function() {
     var apiKey;
     var apiSecret;
     var environment;
+    var suiteRequestOptionCreatorOptions;
 
     beforeEach(function() {
       apiKey = 'apikey';
       apiSecret = 'apiSecret';
       environment = 'environment';
+
+      suiteRequestOptionCreatorOptions = {
+        apiKey: 'apikey',
+        apiSecret: 'apiSecret',
+        environment: 'environment',
+        rejectUnauthorized: true
+      };
 
       this.sandbox.stub(AdministratorAPI, 'create').returns('FromAdministratorEndpointStub');
       this.sandbox.stub(ContactAPI, 'create').returns('FromContactEndpointStub');
@@ -147,8 +170,8 @@ describe('SuiteApi', function() {
       this.sandbox.stub(ExternalEventAPI, 'create').returns('FromExternalEventEndpointStub');
       this.sandbox.stub(SettingsAPI, 'create').returns('FromSettingsEndpointStub');
       this.sandbox.stub(FlipperAPI, 'create').returns('FromFlipperEndpointStub');
-      this.sandbox.stub(SuiteRequestOptions, 'createForInternalApi').withArgs(environment).returns('SuiteRequestOptionsStub');
-      this.sandbox.stub(SuiteRequestOptions, 'createForServiceApi').withArgs(environment).returns('SuiteServiceRequestOptionsStub');
+      this.sandbox.stub(SuiteRequestOptions, 'createForInternalApi').withArgs(suiteRequestOptionCreatorOptions).returns('SuiteRequestOptionsStub');
+      this.sandbox.stub(SuiteRequestOptions, 'createForServiceApi').withArgs(suiteRequestOptionCreatorOptions).returns('SuiteServiceRequestOptionsStub');
       var suiteRequestStub = this.sandbox.stub(SuiteRequest, 'create');
       suiteRequestStub.withArgs(apiKey, apiSecret, 'SuiteRequestOptionsStub').returns('SuiteRequestStub');
       suiteRequestStub.withArgs(apiKey, apiSecret, 'SuiteServiceRequestOptionsStub').returns('SuiteServiceRequestStub');

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "co-request": "0.2.0",
     "escher-auth": "0.2.4",
     "escher-keypool": "1.0.2",
-    "escher-suiteapi-js": "1.0.0",
+    "escher-suiteapi-js": "1.1.0",
     "flat": "1.5.0",
     "lodash": "3.3.1",
     "logentries-logformat": "0.0.2",


### PR DESCRIPTION
I changed the way we use escher-suiteapi-js to take advantage of it's configurability so we can use Escher on HTTP now, useful when developing on ett.local.
Also added proxy methods to two already existing Suite API endpoints so we can load an individual email by email ID and update an existing email. Those two are needed in the content-editor service.