### PR TITLE
Expose escher error message

### DIFF
--- a/authentication/url/index.js
+++ b/authentication/url/index.js
@@ -23,10 +23,14 @@ var SuiteSignedUrlAuthenticator = function(options) {
 SuiteSignedUrlAuthenticator.prototype = {
 
   authenticate: function(url, host) {
+    var err;
+
     try {
       this.escher.authenticate(this._getAuthParams(url, host), this._getKeyDb());
     } catch (ex) {
-      throw new Error('Escher authentication');
+      err = new Error('Escher authentication');
+      err.reason = ex.message;
+      throw err;
     }
   },
 

--- a/authentication/url/index.spec.js
+++ b/authentication/url/index.spec.js
@@ -55,17 +55,20 @@ describe('Suite API authentication', function() {
 
 
   it('should thrown an error if escher auth fails', function(done) {
-    fakeEscher.authenticate.throws();
+    fakeEscher.authenticate.throws(new Error('The credential scope is invalid'));
 
     var suiteSignedUrlAuthenticator = new SuiteSignedUrlAuthenticator({
       credentialScope: 'testCredentialScope',
       escherSecret: 'testEscherSecret'
     });
 
+    var err = new Error('Escher authentication');
+    err.reason = 'The credential scope is invalid';
+
     try {
       suiteSignedUrlAuthenticator.authenticate('testUrl', 'testHost');
     } catch (ex) {
-      expect(ex).to.eql(new Error('Escher authentication'));
+      expect(ex).to.eql(err);
       done();
     }
   });


### PR DESCRIPTION
To know what's happened under the hood: `{ [Error: Escher authentication] reason: 'The credential scope is invalid' }`

User still sees: `Escher authentication`