### PR TITLE
fix(endpoints): /email/:emailId:/raw is deprecated in Suite API now

### DIFF
--- a/api/endpoints/email/index.js
+++ b/api/endpoints/email/index.js
@@ -74,13 +74,6 @@ _.extend(Email.prototype, {
   },
 
 
-  getRaw: function(payload, options) {
-    return this._requireParameters(payload, ['email_id']).then(
-      fetchFactory(payload, options, '/email/%s/raw').bind(this)
-    );
-  },
-
-
   patch: function(payload, options) {
     return this._requireParameters(payload, ['email_id']).then(function() {
       logger.log('email_patch');

--- a/api/endpoints/email/index.spec.js
+++ b/api/endpoints/email/index.spec.js
@@ -57,12 +57,6 @@ describe('SuiteAPI Email endpoint', function() {
   });
 
 
-  describe('#getRaw', function() {
-    testApiMethod(EmailAPI, 'getRaw').withArgs({ email_id: 12 }).shouldGetResultFromEndpoint('/email/12/raw');
-    testApiMethod(EmailAPI, 'getRaw').withArgs({}).shouldThrowMissingParameterError('email_id');
-  });
-
-
   describe('#patch', function() {
     testApiMethod(EmailAPI, 'patch').withArgs({
       email_id: 12,


### PR DESCRIPTION
You can load a raw (untracked) email by adding ?raw=1 instead.