### PR TITLE
feat(api): Add parameters to campaign and rename register method

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ necessary data on the invitation form.
 
     suiteAPI.administrator.inviteExistingAdministrator(payload);
 
+#### Campaign
+
+##### create
+
+    suiteAPI.campaign.create(payload);
+
 #### Condition
 
 ##### List

--- a/api/endpoints/campaign/index.js
+++ b/api/endpoints/campaign/index.js
@@ -15,15 +15,17 @@ util.inherits(Campaign, Base);
 
 _.extend(Campaign.prototype, {
 
-  register: function(payload, options) {
-    logger.log('campaign_register');
+  create: function(payload, options) {
+    return this._requireParameters(payload, ['name', 'provider', 'campaign_type', 'channel', 'external_id']).then(function() {
+      logger.log('campaign_create');
 
-    return this._request.post(
-      this._getCustomerId(options),
-      '/campaigns',
-      payload,
-      options
-    );
+      return this._request.post(
+        this._getCustomerId(options),
+        '/campaigns',
+        payload,
+        options
+      );
+    }.bind(this));
   }
 
 });

--- a/api/endpoints/campaign/index.spec.js
+++ b/api/endpoints/campaign/index.spec.js
@@ -5,10 +5,10 @@ var testApiMethod = require('../_test');
 
 describe('SuiteAPI Campaign endpoint', function() {
 
-  describe('#register', function() {
+  describe('#create', function() {
     var json = { 'name': 'testName', 'customer_id': '1', 'external_id': 'korte', 'provider': 'broadcast', 'campaign_type': 'batch', 'channel': 'push' };
 
-    testApiMethod(CampaignAPI, 'register').withArgs(json).shouldPostToEndpoint('/campaigns', json);
+    testApiMethod(CampaignAPI, 'create').withArgs(json).shouldPostToEndpoint('/campaigns', json);
   });
 
 });


### PR DESCRIPTION
BREAKING CHANGE: campaign's register method is renamed to create