### PR TITLE
fix(api-request): don't use clones in nodeCache

### DIFF
--- a/lib/api-request/index.js
+++ b/lib/api-request/index.js
@@ -8,7 +8,7 @@ var SuiteRequestOptions = SuiteRequest.Options;
 
 var config = require('../../config');
 
-var cache = new NodeCache({ stdTTL: config.CACHE_TTL, checkperiod: config.CACHE_TTL + 10 });
+var cache = new NodeCache({ stdTTL: config.CACHE_TTL, checkperiod: config.CACHE_TTL + 10, useClones: false });
 
 var ApiRequest = function(options) {
   this._cacheId = null;


### PR DESCRIPTION
Disable using clones for request caching. See: https://github.com/tcs-de/nodecache#version-3x