### PR TITLE
Return start pages of an administrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,10 @@ Changes the status of the disabled admin back to enabled so logging in becomes p
 ##### [Get Interface Languages](http://documentation.emarsys.com/resource/developers/api/customers/administrator-ui-languages/)
 
     suiteAPI.administrator.getInterfaceLanguages(payload, options);
-    
+
 ##### [Get Start Pages](http://documentation.emarsys.com/resource/querying-start-pages/)
+
+Returns the start pages of an administrator.
 
     suiteAPI.administrator.getStartPages(payload, options);
 
@@ -535,7 +537,7 @@ Lists the purchases of customers per day.
 ##### [Listing Available Fields Choices](http://documentation.emarsys.com/resource/developers/endpoints/contacts/list-field-choices/)
 
     suiteAPI.field.getChoices(payload, options);
-    
+
 ##### Listing Available Fields Choices for multiple fields
 
     suiteAPI.field.getMultipleChoices(payload, options);

--- a/api/endpoints/administrator/index.js
+++ b/api/endpoints/administrator/index.js
@@ -110,13 +110,15 @@ _.extend(Administrator.prototype, {
 
 
   getStartPages: function(payload, options) {
-    logger.log('administrator_get_start_pages');
+    return this._requireParameters(payload, ['administrator_id']).then(() => {
+      logger.log('administrator_get_start_pages');
 
-    return this._request.get(
-      this._getCustomerId(options),
-      this._buildUrl('/administrator/getstartpages', payload),
-      options
-    );
+      return this._request.get(
+        this._getCustomerId(options),
+        util.format('/administrator/%s/getstartpages', payload.administrator_id),
+        options
+      );
+    });
   },
 
 

--- a/api/endpoints/administrator/index.spec.js
+++ b/api/endpoints/administrator/index.spec.js
@@ -8,6 +8,7 @@ var testApiMethod = require('../_test');
 var SuiteRequestError = require('escher-suiteapi-js').Error;
 
 describe('SuiteAPI Administrator endpoint', function() {
+  const ADMINISTRATOR_ID = 12;
 
   describe('#getAdministrators', function() {
     testApiMethod(AdministratorAPI, 'getAdministrators').shouldGetResultFromEndpoint('/administrator');
@@ -20,7 +21,9 @@ describe('SuiteAPI Administrator endpoint', function() {
 
 
   describe('#getStartPages', function() {
-    testApiMethod(AdministratorAPI, 'getStartPages').shouldGetResultFromEndpoint('/administrator/getstartpages');
+    testApiMethod(AdministratorAPI, 'getStartPages').withArgs({
+      administrator_id: ADMINISTRATOR_ID
+    }).shouldGetResultFromEndpoint(`/administrator/${ADMINISTRATOR_ID}/getstartpages`);
   });
 
 
@@ -31,9 +34,9 @@ describe('SuiteAPI Administrator endpoint', function() {
 
   describe('#patchAdministrator', function() {
     testApiMethod(AdministratorAPI, 'patchAdministrator').withArgs({
-      administrator_id: 12,
+      administrator_id: ADMINISTRATOR_ID,
       data: 'someData'
-    }).shouldPostToEndpoint('/administrator/12/patch', {
+    }).shouldPostToEndpoint(`/administrator/${ADMINISTRATOR_ID}/patch`, {
       data: 'someData'
     });
 
@@ -321,9 +324,9 @@ describe('SuiteAPI Administrator endpoint', function() {
 
   describe('#enableAdministrator', function() {
     testApiMethod(AdministratorAPI, 'enableAdministrator').withArgs({
-      administrator_id: 12,
+      administrator_id: ADMINISTRATOR_ID,
       data: 'someData'
-    }).shouldPostToEndpoint('/administrator/12/patch', sinon.match({
+    }).shouldPostToEndpoint(`/administrator/${ADMINISTRATOR_ID}/patch`, sinon.match({
       data: 'someData'
     }));
 
@@ -362,9 +365,9 @@ describe('SuiteAPI Administrator endpoint', function() {
 
   describe('#disableAdministrator', function() {
     testApiMethod(AdministratorAPI, 'disableAdministrator').withArgs({
-      administrator_id: 12,
+      administrator_id: ADMINISTRATOR_ID,
       data: 'someData'
-    }).shouldPostToEndpoint('/administrator/12/patch', sinon.match({
+    }).shouldPostToEndpoint(`/administrator/${ADMINISTRATOR_ID}/patch`, sinon.match({
       data: 'someData'
     }));
 
@@ -400,10 +403,10 @@ describe('SuiteAPI Administrator endpoint', function() {
 
   describe('#deleteAdministrator', function() {
     testApiMethod(AdministratorAPI, 'deleteAdministrator').withArgs({
-      administrator_id: 12,
+      administrator_id: ADMINISTRATOR_ID,
       successor_administrator_id: 55,
       data: 'someData'
-    }).shouldPostToEndpoint('/administrator/12/delete', {
+    }).shouldPostToEndpoint(`/administrator/${ADMINISTRATOR_ID}/delete`, {
       data: 'someData',
       successor_administrator_id: 55
     });


### PR DESCRIPTION
This PR adds an administrator id parameter to the `administrator.getStartPages` method, to return the start pages of individual admins.