### PR TITLE
feat(api): adds getRestrictedStartPage method

### DIFF
--- a/api/endpoints/administrator/index.js
+++ b/api/endpoints/administrator/index.js
@@ -110,8 +110,19 @@ _.extend(Administrator.prototype, {
 
 
   getStartPages: function(payload, options) {
+    logger.log('administrator_get_start_pages');
+
+    return this._request.get(
+      this._getCustomerId(options),
+      util.format('/administrator/getstartpages'),
+      options
+    );
+  },
+
+
+  getRestrictedStartPages: function(payload, options) {
     return this._requireParameters(payload, ['administrator_id']).then(() => {
-      logger.log('administrator_get_start_pages');
+      logger.log('administrator_get_restricted_start_pages');
 
       return this._request.get(
         this._getCustomerId(options),

--- a/api/endpoints/administrator/index.spec.js
+++ b/api/endpoints/administrator/index.spec.js
@@ -21,7 +21,13 @@ describe('SuiteAPI Administrator endpoint', function() {
 
 
   describe('#getStartPages', function() {
-    testApiMethod(AdministratorAPI, 'getStartPages').withArgs({
+    testApiMethod(AdministratorAPI, 'getStartPages')
+      .shouldGetResultFromEndpoint('/administrator/getstartpages');
+  });
+
+
+  describe('#getRestrictedStartPages', function() {
+    testApiMethod(AdministratorAPI, 'getRestrictedStartPages').withArgs({
       administrator_id: ADMINISTRATOR_ID
     }).shouldGetResultFromEndpoint(`/administrator/${ADMINISTRATOR_ID}/getstartpages`);
   });


### PR DESCRIPTION
This PR adds a method to call another version of the start pages API endpoint.