### PR TITLE
feat(api): uses per admin endpoint in getAdministrator

### DIFF
--- a/api/endpoints/administrator/index.js
+++ b/api/endpoints/administrator/index.js
@@ -57,19 +57,11 @@ _.extend(Administrator.prototype, {
       var administratorId = payload.administrator_id;
       payload = this._cleanPayload(payload, ['administrator_id']);
 
-      return this.getAdministrators(payload, options).then(function(response) {
-        var firstAdmin = new AdminList(response.body.data).getFirstById(administratorId);
-
-        if (firstAdmin) {
-          return Promise.resolve({
-            body: {
-              data: firstAdmin
-            }
-          });
-        }
-
-        return Promise.reject(new SuiteRequestError('There is no admin for this customer', 400));
-      }.bind(this));
+      return this._request.get(
+        this._getCustomerId(options),
+        this._buildUrl(`/administrator/${administratorId}`, payload),
+        options
+      );
     }.bind(this));
   },
 

--- a/api/endpoints/administrator/index.spec.js
+++ b/api/endpoints/administrator/index.spec.js
@@ -51,32 +51,20 @@ describe('SuiteAPI Administrator endpoint', function() {
 
 
   describe('#getAdministrator', function() {
+    const administratorId = '3';
+
     testApiMethod(AdministratorAPI, 'getAdministrator').withArgs({
-      administrator_id: '3'
+      administrator_id: administratorId
     })
     .requestResponseWith({
       body: {
-        data: [
-          { id: '1', superadmin: '0' },
-          { id: '2', superadmin: '1' },
-          { id: '3', superadmin: '0' }
-        ]
+        data: { id: administratorId, superadmin: '0' }
       }
-    }).shouldGetResultFromEndpoint('/administrator', {
-      body: { data: { id: '3', superadmin: '0' } }
+    }).shouldGetResultFromEndpoint(`/administrator/${administratorId}`, {
+      body: { data: { id: administratorId, superadmin: '0' } }
     });
 
     testApiMethod(AdministratorAPI, 'getAdministrator').shouldThrowMissingParameterError('administrator_id');
-
-
-    describe('requesting admin who not exists', function() {
-      testApiMethod(AdministratorAPI, 'getAdministrator').withArgs({
-        administrator_id: '12345'
-      })
-      .requestResponseWith({
-        body: { data: [{ id: '1', superadmin: '0' }] }
-      }).shouldThrowError(new SuiteRequestError('There is no admin for this customer', 400));
-    });
   });
 
 


### PR DESCRIPTION
This PR changes the endpoint that is used in getAdministrator method. This changes the code that is thrown on not existing admin from 400 to 404.