### PR TITLE
feat(api): Adding runForMultipleContacts and multipleContactsRunStats to Segment endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,14 @@ Updates alternate texts.
 
     suiteAPI.segment.updateContactCriteria(payload, options);
 
+##### [Run Segment for Multiple Contacts](https://dev.emarsys.com/v2/segments/run-a-contact-segment-batch)
+
+    suiteAPI.segment.runForMultipleContacts(payload, options);
+
+##### [Get Segment Run Status for Multiple Contacts](https://dev.emarsys.com/v2/segments/poll-the-status-of-a-segment-run-for-multiple-contacts)
+
+    suiteAPI.segment.multipleContactsRunStatus(payload, options);
+
 #### Combined Segment
 
 ##### [List combined segments](https://dev.emarsys.com/v2/segments/list-combined-segments)

--- a/api/endpoints/segment/index.js
+++ b/api/endpoints/segment/index.js
@@ -100,8 +100,32 @@ _.extend(Segment.prototype, {
         options
       );
     }.bind(this));
-  }
+  },
 
+  runForMultipleContacts: function(payload, options) {
+    return this._requireParameters(payload, ['segment_id']).then(function() {
+      logger.log('segment_run_for_multiple_contacts');
+
+      return this._request.post(
+        this._getCustomerId(options),
+        util.format('/filter/%s/runs', payload.segment_id),
+        {},
+        options
+      );
+    }.bind(this));
+  },
+
+  multipleContactsRunStatus: function(payload, options) {
+    return this._requireParameters(payload, ['run_id']).then(function() {
+      logger.log('segment_multiple_contacts_run_status');
+
+      return this._request.get(
+        this._getCustomerId(options),
+        util.format('/filter/runs/%s', payload.run_id),
+        options
+      );
+    }.bind(this));
+  }
 });
 
 Segment.create = function(request, options) {

--- a/api/endpoints/segment/index.spec.js
+++ b/api/endpoints/segment/index.spec.js
@@ -99,4 +99,20 @@ describe('SuiteAPI Segment endpoint', function() {
     testApiMethod(SegmentAPI, 'updateContactCriteria').shouldThrowMissingParameterError('segment_id');
   });
 
+  describe('#runForMultipleContacts', function() {
+    testApiMethod(SegmentAPI, 'runForMultipleContacts').withArgs({
+      segment_id: 8362723
+    }).shouldPostToEndpoint('/filter/8362723/runs', {});
+
+    testApiMethod(SegmentAPI, 'runForMultipleContacts').shouldThrowMissingParameterError('segment_id');
+  });
+
+  describe('#multipleContactsRunStatus', function() {
+    const runId = 'abc-efg-63636';
+    testApiMethod(SegmentAPI, 'multipleContactsRunStatus').withArgs({
+      run_id: runId
+    }).shouldGetResultFromEndpoint(`/filter/runs/${runId}`);
+
+    testApiMethod(SegmentAPI, 'multipleContactsRunStatus').shouldThrowMissingParameterError('run_id');
+  });
 });


### PR DESCRIPTION
Adding function for triggering a segment run for multiple contacts and monitoring the related segment runs. We need to move to V2 of the API in ME because the segment runs are broken with the old API version if a customer is triggering a launch for the same segment at the same time.

Issue: [SUITEDEV-16975](https://emarsys.jira.com/browse/SUITEDEV-16975)

### All Submissions:
* [Y] Have you followed our guidelines?
* [Y] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New API Endpoints:
* [Y] Is it a _public_ API endpoint that you want to implement?
* [Y] Did you follow other API endpoint implementations?
* [Y] Did you cover it with test(s)?
* [Y] Did you documented it in the [read me](https://github.com/emartech/suite-js-sdk/blob/master/README.md)?
* [Y] Did you link the Emarsys Developer Hub?
