### PR TITLE
fix security vulnerability by updating axios

### DIFF
--- a/api/endpoints/_test/request-error.js
+++ b/api/endpoints/_test/request-error.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var SuiteRequestError = require('escher-suiteapi-js').Error;
+var SuiteRequestError = require('../../../lib/api-request/error');
 
 module.exports = {
   shouldThrowError: function(error) {

--- a/api/endpoints/administrator/index.js
+++ b/api/endpoints/administrator/index.js
@@ -5,7 +5,7 @@ var logger = require('logentries-logformat')('suite-sdk');
 var _ = require('lodash');
 
 var AdminList = require('./index.admin-list.js');
-var SuiteRequestError = require('escher-suiteapi-js').Error;
+var SuiteRequestError = require('../../../lib/api-request/error');
 var passwordGenerator = require('../../../lib/password-generator');
 var dateHelper = require('../../../lib/date-helper');
 

--- a/api/endpoints/administrator/index.spec.js
+++ b/api/endpoints/administrator/index.spec.js
@@ -5,7 +5,7 @@ var AdministratorAPI = require('./');
 var PasswordGenerator = require('../../../lib/password-generator');
 var DateHelper = require('../../../lib/date-helper');
 var testApiMethod = require('../_test');
-var SuiteRequestError = require('escher-suiteapi-js').Error;
+var SuiteRequestError = require('../../../lib/api-request/error');
 
 describe('SuiteAPI Administrator endpoint', function() {
   const ADMINISTRATOR_ID = 12;

--- a/api/index.js
+++ b/api/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var SuiteRequest = require('escher-suiteapi-js');
 var ApiRequest = require('./../lib/api-request');
+var SuiteRequestError = require('./../lib/api-request/error');
 
 var AdministratorAPI = require('./endpoints/administrator');
 var AutomationCenterAPI = require('./endpoints/automationcenter');
@@ -131,4 +131,4 @@ module.exports.Segment = SegmentAPI;
 module.exports.Settings = SettingsAPI;
 module.exports.Keyring = KeyringAPI;
 
-module.exports.SuiteRequestError = SuiteRequest.Error;
+module.exports.SuiteRequestError = SuiteRequestError;

--- a/api/index.spec.js
+++ b/api/index.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var SuiteRequest = require('escher-suiteapi-js');
+const { EscherRequest, EscherRequestOption } = require('@emartech/escher-request');
 var SuiteAPI = require('./');
 
 var AdministratorAPI = require('./endpoints/administrator');
@@ -22,7 +22,6 @@ var SettingsAPI = require('./endpoints/settings');
 var KeyringAPI = require('./endpoints/keyring');
 
 var Request = require('./../lib/api-request');
-var SuiteRequestOptions = SuiteRequest.Options;
 
 var config = require('../config');
 
@@ -34,10 +33,10 @@ describe('SuiteApi', function() {
 
     beforeEach(function() {
       stubRequestCreation = (function() {
-        sinon.stub(SuiteRequest, 'create');
+        sinon.stub(EscherRequest, 'create');
         sinon.stub(Request, 'create');
-        sinon.stub(SuiteRequestOptions, 'createForInternalApi').returns('SuiteRequestOptionsStub');
-        sinon.stub(SuiteRequestOptions, 'createForServiceApi').returns('SuiteServiceRequestOptionsStub');
+        sinon.stub(EscherRequestOption, 'createForInternalApi').returns('SuiteRequestOptionsStub');
+        sinon.stub(EscherRequestOption, 'createForServiceApi').returns('SuiteServiceRequestOptionsStub');
       }).bind(this);
     });
 
@@ -210,9 +209,9 @@ describe('SuiteApi', function() {
       sinon.stub(SettingsAPI, 'create').returns('FromSettingsEndpointStub');
       sinon.stub(KeyringAPI, 'create').returns('FromKeyringEndpointStub');
 
-      var suiteRequestStub = sinon.stub(SuiteRequest, 'create');
-      suiteRequestStub.withArgs(apiKey, apiSecret, 'SuiteRequestOptionsStub').returns('SuiteRequestStub');
-      suiteRequestStub.withArgs(apiKey, apiSecret, 'SuiteServiceRequestOptionsStub').returns('SuiteServiceRequestStub');
+      var escherRequestStub = sinon.stub(EscherRequest, 'create');
+      escherRequestStub.withArgs(apiKey, apiSecret, 'SuiteRequestOptionsStub').returns('SuiteRequestStub');
+      escherRequestStub.withArgs(apiKey, apiSecret, 'SuiteServiceRequestOptionsStub').returns('SuiteServiceRequestStub');
       fakeRequest = { id: 'fakeRequestFrom' };
       sinon.stub(Request, 'create').withArgs(options).returns(fakeRequest);
       sdk = SuiteAPI.create(options);

--- a/lib/api-request/error.js
+++ b/lib/api-request/error.js
@@ -1,0 +1,25 @@
+'use strict';
+
+class SuiteRequestError extends Error {
+  constructor(message, code, response, originalCode) {
+    super(message);
+
+    this.code = code;
+    this.originalCode = originalCode;
+    this.name = 'SuiteRequestError';
+
+    if (response) {
+      this.data = response.data || response;
+    } else {
+      this.data = {
+        replyText: message
+      };
+    }
+  }
+
+  static createFromEscherRequestError(error) {
+    return new SuiteRequestError(error.message, error.code, { data: error.data }, error.originalCode);
+  }
+}
+
+module.exports = SuiteRequestError;

--- a/lib/api-request/error.spec.js
+++ b/lib/api-request/error.spec.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const { EscherRequestError } = require('@emartech/escher-request');
+const SuiteRequestError = require('./error');
+
+describe('SuiteRequestError', function() {
+  describe('constructor', function() {
+    it('should extend base Error class', function() {
+      const error = new SuiteRequestError();
+
+      expect(error).to.be.an.instanceOf(Error);
+    });
+
+    it('should store constructor parameters', function() {
+      const error = new SuiteRequestError('Invalid request', 400, {
+        data: {
+          replyText: 'Too long',
+          detailedMessage: 'Line too long'
+        }
+      }, 'ECONNABORTED');
+
+      expect(error.message).to.eql('Invalid request');
+      expect(error.code).to.eql(400);
+      expect(error.data).to.eql({
+        replyText: 'Too long',
+        detailedMessage: 'Line too long'
+      });
+      expect(error.originalCode).to.eql('ECONNABORTED');
+    });
+
+    it('should store response as is when no data attribute present', function() {
+      const error = new SuiteRequestError('Invalid request', 400, {
+        replyText: 'Too long',
+        detailedMessage: 'Line too long'
+      });
+
+      expect(error.message).to.eql('Invalid request');
+      expect(error.code).to.eql(400);
+      expect(error.data).to.eql({
+        replyText: 'Too long',
+        detailedMessage: 'Line too long'
+      });
+    });
+
+    it('should always contain data on error', function() {
+      const error = new SuiteRequestError('Unauthorized');
+
+      expect(error.data).to.eql({ replyText: 'Unauthorized' });
+    });
+  });
+
+  describe('createFromEscherRequestError', function() {
+    it('should map message, code and originalCode properties', function() {
+      const escherRequestError = new EscherRequestError('Unauthorized', 499, '', 'ECONNABORTED');
+      const error = SuiteRequestError.createFromEscherRequestError(escherRequestError);
+
+      expect(error.message).to.eql('Unauthorized');
+      expect(error.code).to.eql(499);
+      expect(error.originalCode).to.eql('ECONNABORTED');
+    });
+
+    it('should map default data', function() {
+      const escherRequestError = new EscherRequestError('Unauthorized', 0);
+      const error = SuiteRequestError.createFromEscherRequestError(escherRequestError);
+
+      expect(error.data).to.eql({ replyText: 'Unauthorized' });
+    });
+
+    it('should map text data', function() {
+      const escherRequestError = new EscherRequestError('', 0, 'response text');
+      const error = SuiteRequestError.createFromEscherRequestError(escherRequestError);
+
+      expect(error.data).to.eql('response text');
+    });
+
+    it('should map data object', function() {
+      const escherRequestError = new EscherRequestError('', 0, { test: 'test' });
+      const error = SuiteRequestError.createFromEscherRequestError(escherRequestError);
+
+      expect(error.data).to.eql({ test: 'test' });
+    });
+
+    it('should map data object with data property', function() {
+      const escherRequestError = new EscherRequestError('', 0, { data: { test: 'test' } });
+      const error = SuiteRequestError.createFromEscherRequestError(escherRequestError);
+
+      expect(error.data).to.eql({ test: 'test' });
+    });
+
+    it('should map data object with nested data properties', function() {
+      const escherRequestError = new EscherRequestError('', 0, { data: { data: { test: 'test' } } });
+      const error = SuiteRequestError.createFromEscherRequestError(escherRequestError);
+
+      expect(error.data).to.eql({ data: { test: 'test' } });
+    });
+  });
+});

--- a/lib/api-request/index.js
+++ b/lib/api-request/index.js
@@ -3,8 +3,8 @@
 var _ = require('lodash');
 var NodeCache = require('node-cache');
 
-var SuiteRequest = require('escher-suiteapi-js');
-var SuiteRequestOptions = SuiteRequest.Options;
+const { EscherRequest, EscherRequestOption, EscherRequestError } = require('@emartech/escher-request');
+const SuiteRequestError = require('./error');
 
 var config = require('../../config');
 
@@ -41,7 +41,8 @@ _.extend(ApiRequest.prototype, {
         }
 
         return returnValue;
-      }.bind(this));
+      }.bind(this))
+      .catch(this._mapEscherRequestErrorToSuiteRequestError);
   },
 
   post: function(customerId, url, data, options) {
@@ -50,7 +51,7 @@ _.extend(ApiRequest.prototype, {
     this._suiteRequest = this._createRequest(opts);
 
     var completeUrl = this._assembleUrl(customerId, url);
-    return this._suiteRequest.post(completeUrl, data, options);
+    return this._suiteRequest.post(completeUrl, data, options).catch(this._mapEscherRequestErrorToSuiteRequestError);
   },
 
   put: function(customerId, url, data, options) {
@@ -59,7 +60,7 @@ _.extend(ApiRequest.prototype, {
     this._suiteRequest = this._createRequest(opts);
 
     var completeUrl = this._assembleUrl(customerId, url);
-    return this._suiteRequest.put(completeUrl, data, options);
+    return this._suiteRequest.put(completeUrl, data, options).catch(this._mapEscherRequestErrorToSuiteRequestError);
   },
 
   delete: function(customerId, url, options) {
@@ -68,7 +69,7 @@ _.extend(ApiRequest.prototype, {
     this._suiteRequest = this._createRequest(opts);
 
     var completeUrl = this._assembleUrl(customerId, url);
-    return this._suiteRequest.delete(completeUrl, options);
+    return this._suiteRequest.delete(completeUrl, options).catch(this._mapEscherRequestErrorToSuiteRequestError);
   },
 
   setCache: function(cacheId) {
@@ -103,8 +104,8 @@ _.extend(ApiRequest.prototype, {
   },
 
   _createRequest: function(options) {
-    var requestOptions = SuiteRequestOptions.createForInternalApi(options);
-    return SuiteRequest.create(options.apiKey, options.apiSecret, requestOptions);
+    var requestOptions = EscherRequestOption.createForInternalApi(options);
+    return EscherRequest.create(options.apiKey, options.apiSecret, requestOptions);
   },
 
   _getCacheKey: function(method, url, data) {
@@ -116,6 +117,13 @@ _.extend(ApiRequest.prototype, {
     ];
 
     return cacheIdParts.join('#');
+  },
+
+  _mapEscherRequestErrorToSuiteRequestError: function(error) {
+    if (error instanceof EscherRequestError) {
+      throw SuiteRequestError.createFromEscherRequestError(error);
+    }
+    throw error;
   }
 
 });

--- a/lib/api-request/index.spec.js
+++ b/lib/api-request/index.spec.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var Request = require('./');
-var SuiteRequest = require('escher-suiteapi-js');
+const { EscherRequest, EscherRequestOption, EscherRequestError } = require('@emartech/escher-request');
+const SuiteRequestError = require('./error');
 var _ = require('lodash');
 
 describe('ApiRequest', function() {
@@ -15,7 +16,7 @@ describe('ApiRequest', function() {
     it('should call suite request\'s get', function(done) {
       var promiseRespond = { dummyData: 12 };
 
-      var getApiRequest = sinon.stub(SuiteRequest.prototype, 'get').callsFake(function() {
+      var getApiRequest = sinon.stub(EscherRequest.prototype, 'get').callsFake(function() {
         return getPromiseResolvesWith(promiseRespond);
       });
 
@@ -31,7 +32,7 @@ describe('ApiRequest', function() {
     it('should throw the sdk error if something went wrong', function(done) {
       var promiseError = new Error('yoError');
 
-      sinon.stub(SuiteRequest.prototype, 'get').callsFake(function() {
+      sinon.stub(EscherRequest.prototype, 'get').callsFake(function() {
         return getPromiseRejectsWith(promiseError);
       });
 
@@ -45,20 +46,40 @@ describe('ApiRequest', function() {
       });
     });
 
+    it('should map EscherRequestError to SuiteRequestError', function(done) {
+      var promiseError = new EscherRequestError('yoError', 499, { foo: 'bar' }, 'ECONNABORTED');
+
+      sinon.stub(EscherRequest.prototype, 'get').callsFake(function() {
+        return getPromiseRejectsWith(promiseError);
+      });
+
+      var request = new Request({});
+
+      request.get(2, '/administrator').then(function() {
+        throw new Error('Promise should be rejected');
+      }).catch(function(error) {
+        expect(error).to.be.an.instanceOf(SuiteRequestError);
+        expect(error.message).to.equal(promiseError.message);
+        expect(error.code).to.equal(promiseError.code);
+        expect(error.data).to.equal(promiseError.data);
+        expect(error.originalCode).to.equal(promiseError.originalCode);
+      }).then(done).catch(done);
+    });
+
 
     it('should use the appropriate keys from the given options object', function(done) {
       var options = getDefaultOptions();
       var expectedOptions = _.omit(options, 'some_option');
 
-      sinon.stub(SuiteRequest.prototype, 'get').callsFake(function() {
+      sinon.stub(EscherRequest.prototype, 'get').callsFake(function() {
         return getPromiseResolvesWith({});
       });
-      sinon.stub(SuiteRequest.Options, 'createForInternalApi').returns({});
+      sinon.stub(EscherRequestOption, 'createForInternalApi').returns({});
 
       var request = new Request({});
 
       request.get(2, '/administrator', options).then(function() {
-        expect(SuiteRequest.Options.createForInternalApi).to.have.been.calledWith(expectedOptions);
+        expect(EscherRequestOption.createForInternalApi).to.have.been.calledWith(expectedOptions);
       }).then(done).catch(done);
     });
 
@@ -67,15 +88,15 @@ describe('ApiRequest', function() {
       var options = getDefaultOptions();
       var expectedOptions = _.omit(options, 'some_option');
 
-      sinon.stub(SuiteRequest.prototype, 'get').callsFake(function() {
+      sinon.stub(EscherRequest.prototype, 'get').callsFake(function() {
         return getPromiseResolvesWith({});
       });
-      sinon.stub(SuiteRequest.Options, 'createForInternalApi').returns({});
+      sinon.stub(EscherRequestOption, 'createForInternalApi').returns({});
 
       var request = new Request(options);
 
       request.get(2, '/administrator').then(function() {
-        expect(SuiteRequest.Options.createForInternalApi).to.have.been.calledWith(expectedOptions);
+        expect(EscherRequestOption.createForInternalApi).to.have.been.calledWith(expectedOptions);
       }).then(done).catch(done);
     });
 
@@ -90,7 +111,7 @@ describe('ApiRequest', function() {
       });
 
       it('should return cached result after the first request', function(done) {
-        sinon.stub(SuiteRequest.prototype, 'get')
+        sinon.stub(EscherRequest.prototype, 'get')
           .onFirstCall().returns(getPromiseResolvesWith(firstResponse))
           .onSecondCall().returns(getPromiseResolvesWith(secondResponse));
 
@@ -108,7 +129,7 @@ describe('ApiRequest', function() {
 
 
       it('should get response from cache for another request with the same cache id', function(done) {
-        sinon.stub(SuiteRequest.prototype, 'get')
+        sinon.stub(EscherRequest.prototype, 'get')
           .onFirstCall().returns(getPromiseResolvesWith(firstResponse))
           .onSecondCall().returns(getPromiseResolvesWith(secondResponse));
 
@@ -128,7 +149,7 @@ describe('ApiRequest', function() {
 
 
       it('should get a new response for a request with another cache id', function(done) {
-        sinon.stub(SuiteRequest.prototype, 'get')
+        sinon.stub(EscherRequest.prototype, 'get')
           .onFirstCall().returns(getPromiseResolvesWith(firstResponse))
           .onSecondCall().returns(getPromiseResolvesWith(secondResponse));
 
@@ -161,7 +182,7 @@ describe('ApiRequest', function() {
       var promiseRespond = { dummyData: 12 };
       var sendData = { yo: 5 };
 
-      var postApiRequest = sinon.stub(SuiteRequest.prototype, 'post').callsFake(function() {
+      var postApiRequest = sinon.stub(EscherRequest.prototype, 'post').callsFake(function() {
         return getPromiseResolvesWith(promiseRespond);
       });
 
@@ -177,7 +198,7 @@ describe('ApiRequest', function() {
     it('should throw the sdk error if something went wrong', function(done) {
       var promiseError = new Error('yoError');
 
-      sinon.stub(SuiteRequest.prototype, 'post').callsFake(function() {
+      sinon.stub(EscherRequest.prototype, 'post').callsFake(function() {
         return getPromiseRejectsWith(promiseError);
       });
 
@@ -187,6 +208,26 @@ describe('ApiRequest', function() {
         expect(error).to.equal(promiseError);
         done();
       });
+    });
+
+    it('should map EscherRequestError to SuiteRequestError', function(done) {
+      var promiseError = new EscherRequestError('yoError', 499, { foo: 'bar' }, 'ECONNABORTED');
+
+      sinon.stub(EscherRequest.prototype, 'post').callsFake(function() {
+        return getPromiseRejectsWith(promiseError);
+      });
+
+      var request = new Request({});
+
+      request.post(2, '/administrator', {}).then(function() {
+        throw new Error('Promise should be rejected');
+      }).catch(function(error) {
+        expect(error).to.be.an.instanceOf(SuiteRequestError);
+        expect(error.message).to.equal(promiseError.message);
+        expect(error.code).to.equal(promiseError.code);
+        expect(error.data).to.equal(promiseError.data);
+        expect(error.originalCode).to.equal(promiseError.originalCode);
+      }).then(done).catch(done);
     });
 
 
@@ -212,7 +253,7 @@ describe('ApiRequest', function() {
       var promiseRespond = { dummyData: 12 };
       var sendData = { yo: 5 };
 
-      var putApiRequest = sinon.stub(SuiteRequest.prototype, 'put').callsFake(function() {
+      var putApiRequest = sinon.stub(EscherRequest.prototype, 'put').callsFake(function() {
         return getPromiseResolvesWith(promiseRespond);
       });
 
@@ -227,7 +268,7 @@ describe('ApiRequest', function() {
 
     it('should throw the sdk error if something went wrong', function(done) {
       var promiseError = new Error('yoError');
-      sinon.stub(SuiteRequest.prototype, 'put').callsFake(function() {
+      sinon.stub(EscherRequest.prototype, 'put').callsFake(function() {
         return getPromiseRejectsWith(promiseError);
       });
       var request = new Request({});
@@ -236,6 +277,26 @@ describe('ApiRequest', function() {
         expect(error).to.equal(promiseError);
         done();
       });
+    });
+
+    it('should map EscherRequestError to SuiteRequestError', function(done) {
+      var promiseError = new EscherRequestError('yoError', 499, { foo: 'bar' }, 'ECONNABORTED');
+
+      sinon.stub(EscherRequest.prototype, 'put').callsFake(function() {
+        return getPromiseRejectsWith(promiseError);
+      });
+
+      var request = new Request({});
+
+      request.put(2, '/administrator', {}).then(function() {
+        throw new Error('Promise should be rejected');
+      }).catch(function(error) {
+        expect(error).to.be.an.instanceOf(SuiteRequestError);
+        expect(error.message).to.equal(promiseError.message);
+        expect(error.code).to.equal(promiseError.code);
+        expect(error.data).to.equal(promiseError.data);
+        expect(error.originalCode).to.equal(promiseError.originalCode);
+      }).then(done).catch(done);
     });
 
 
@@ -259,7 +320,7 @@ describe('ApiRequest', function() {
     it('should call suite request\'s delete', function(done) {
       var promiseRespond = { dummyData: 12 };
 
-      var putApiRequest = sinon.stub(SuiteRequest.prototype, 'delete').callsFake(function() {
+      var putApiRequest = sinon.stub(EscherRequest.prototype, 'delete').callsFake(function() {
         return getPromiseResolvesWith(promiseRespond);
       });
 
@@ -274,7 +335,7 @@ describe('ApiRequest', function() {
 
     it('should throw the sdk error if something went wrong', function(done) {
       var promiseError = new Error('yoError');
-      sinon.stub(SuiteRequest.prototype, 'delete').callsFake(function() {
+      sinon.stub(EscherRequest.prototype, 'delete').callsFake(function() {
         return getPromiseRejectsWith(promiseError);
       });
       var request = new Request({});
@@ -285,20 +346,40 @@ describe('ApiRequest', function() {
       });
     });
 
+    it('should map EscherRequestError to SuiteRequestError', function(done) {
+      var promiseError = new EscherRequestError('yoError', 499, { foo: 'bar' }, 'ECONNABORTED');
+
+      sinon.stub(EscherRequest.prototype, 'delete').callsFake(function() {
+        return getPromiseRejectsWith(promiseError);
+      });
+
+      var request = new Request({});
+
+      request.delete(2, '/administrator', {}).then(function() {
+        throw new Error('Promise should be rejected');
+      }).catch(function(error) {
+        expect(error).to.be.an.instanceOf(SuiteRequestError);
+        expect(error.message).to.equal(promiseError.message);
+        expect(error.code).to.equal(promiseError.code);
+        expect(error.data).to.equal(promiseError.data);
+        expect(error.originalCode).to.equal(promiseError.originalCode);
+      }).then(done).catch(done);
+    });
+
 
     it('should use the appropriate keys from the given options object', function(done) {
       var options = getDefaultOptions();
       var expectedOptions = _.omit(options, 'some_option');
 
-      sinon.stub(SuiteRequest.prototype, 'delete').callsFake(function() {
+      sinon.stub(EscherRequest.prototype, 'delete').callsFake(function() {
         return getPromiseResolvesWith({});
       });
-      sinon.stub(SuiteRequest.Options, 'createForInternalApi').returns({});
+      sinon.stub(EscherRequestOption, 'createForInternalApi').returns({});
 
       var request = new Request({});
 
       request.delete(2, '/administrator', options).then(function() {
-        expect(SuiteRequest.Options.createForInternalApi).to.have.been.calledWith(expectedOptions);
+        expect(EscherRequestOption.createForInternalApi).to.have.been.calledWith(expectedOptions);
       }).then(done).catch(done);
     });
 
@@ -333,7 +414,7 @@ describe('ApiRequest', function() {
   };
 
   var assertRequestMethodCalledWithEncodedCustomerName = function(requestMethod, done) {
-    var apiRequest = sinon.stub(SuiteRequest.prototype, requestMethod).callsFake(function() {
+    var apiRequest = sinon.stub(EscherRequest.prototype, requestMethod).callsFake(function() {
       return getPromiseResolvesWith({});
     });
 
@@ -347,15 +428,15 @@ describe('ApiRequest', function() {
     var options = getDefaultOptions();
     var expectedOptions = _.omit(options, 'some_option');
 
-    sinon.stub(SuiteRequest.prototype, requestMethod).callsFake(function() {
+    sinon.stub(EscherRequest.prototype, requestMethod).callsFake(function() {
       return getPromiseResolvesWith({});
     });
-    sinon.stub(SuiteRequest.Options, 'createForInternalApi').returns({});
+    sinon.stub(EscherRequestOption, 'createForInternalApi').returns({});
 
     var request = new Request(options);
 
     request[requestMethod](2, '/administrator', null).then(function() {
-      expect(SuiteRequest.Options.createForInternalApi).to.have.been.calledWith(expectedOptions);
+      expect(EscherRequestOption.createForInternalApi).to.have.been.calledWith(expectedOptions);
     }).then(done).catch(done);
   };
 
@@ -363,15 +444,15 @@ describe('ApiRequest', function() {
     var options = getDefaultOptions();
     var expectedOptions = _.omit(options, 'some_option');
 
-    sinon.stub(SuiteRequest.prototype, requestMethod).callsFake(function() {
+    sinon.stub(EscherRequest.prototype, requestMethod).callsFake(function() {
       return getPromiseResolvesWith({});
     });
-    sinon.stub(SuiteRequest.Options, 'createForInternalApi').returns({});
+    sinon.stub(EscherRequestOption, 'createForInternalApi').returns({});
 
     var request = new Request({});
 
     request[requestMethod](2, '/administrator', null, options).then(function() {
-      expect(SuiteRequest.Options.createForInternalApi).to.have.been.calledWith(expectedOptions);
+      expect(EscherRequestOption.createForInternalApi).to.have.been.calledWith(expectedOptions);
     }).then(done).catch(done);
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,10 @@
       "name": "suite-js-sdk",
       "license": "MIT",
       "dependencies": {
-        "axios": "0.27.2",
+        "@emartech/escher-request": "20.2.1",
+        "axios": "1.6.1",
         "escher-auth": "3.2.4",
         "escher-keypool": "2.0.2",
-        "escher-suiteapi-js": "16.2.0",
         "flat": "5.0.2",
         "lodash": "4.17.21",
         "logentries-logformat": "0.2.0",
@@ -74,6 +74,17 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -84,15 +95,36 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/@emartech/json-logger": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@emartech/json-logger/-/json-logger-3.5.0.tgz",
-      "integrity": "sha512-LvX/lWmQUPpe/w519QrNJ2O0God/ozJyrhueMnqYzA3FjHH8CzLZtx6goaJ3iX4o3K0GsFU2DQZRnYx3MeDRBA==",
+    "node_modules/@emartech/escher-request": {
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@emartech/escher-request/-/escher-request-20.2.1.tgz",
+      "integrity": "sha512-LBtLp69jj8O0S20jDzA0LQu12IZ4uBFI5VQOl/tl/lkFk7llKSdhaYs7YQwxewK5eczfdFF9Shz1ba83IXtkFQ==",
       "dependencies": {
-        "chalk": "2.4.1"
+        "@emartech/json-logger": "7.2.3",
+        "axios": "1.6.0",
+        "axios-retry": "3.4.0",
+        "escher-auth": "3.2.4"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@emartech/escher-request/node_modules/axios": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@emartech/json-logger": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@emartech/json-logger/-/json-logger-7.2.3.tgz",
+      "integrity": "sha512-XLWJmoSy94TJJj86hXondcvtUgcqX+CAI632lYpIVCvF+VYfp4yHAkiew1+T+oHJ/71Pwq2ANpkW7GPereAcBA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -638,6 +670,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -721,12 +754,22 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.4.0.tgz",
+      "integrity": "sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/balanced-match": {
@@ -896,6 +939,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1000,6 +1044,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -1007,7 +1052,8 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1422,6 +1468,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -1445,19 +1492,6 @@
       "integrity": "sha512-LELndUiissutRRhxkq0PGusxW7IrHtR1H+fZA3cm/VUCawtuQ6XNNF6zfcG8z8tBrVheK8103JrF3qKA2V6h1A==",
       "dependencies": {
         "logentries-logformat": "0.2.0"
-      }
-    },
-    "node_modules/escher-suiteapi-js": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/escher-suiteapi-js/-/escher-suiteapi-js-16.2.0.tgz",
-      "integrity": "sha512-ZeljdfkJAX8/GFYAXmlFz7anR0NHKdO792aYbPIhKVEUfMyzwlXhTfhn4iFpWyplF8NbdXlfBehbaGWwaXnEPg==",
-      "dependencies": {
-        "@emartech/json-logger": "3.5.0",
-        "axios": "0.27.2",
-        "escher-auth": "3.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/eslint": {
@@ -2238,6 +2272,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -2515,6 +2550,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-stream": {
@@ -6471,6 +6517,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -6744,6 +6795,11 @@
       "dependencies": {
         "esprima": "~4.0.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -7278,6 +7334,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -7838,6 +7895,14 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "requires": {
+        "regenerator-runtime": "^0.14.0"
+      }
+    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -7845,13 +7910,33 @@
       "dev": true,
       "optional": true
     },
-    "@emartech/json-logger": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@emartech/json-logger/-/json-logger-3.5.0.tgz",
-      "integrity": "sha512-LvX/lWmQUPpe/w519QrNJ2O0God/ozJyrhueMnqYzA3FjHH8CzLZtx6goaJ3iX4o3K0GsFU2DQZRnYx3MeDRBA==",
+    "@emartech/escher-request": {
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@emartech/escher-request/-/escher-request-20.2.1.tgz",
+      "integrity": "sha512-LBtLp69jj8O0S20jDzA0LQu12IZ4uBFI5VQOl/tl/lkFk7llKSdhaYs7YQwxewK5eczfdFF9Shz1ba83IXtkFQ==",
       "requires": {
-        "chalk": "2.4.1"
+        "@emartech/json-logger": "7.2.3",
+        "axios": "1.6.0",
+        "axios-retry": "3.4.0",
+        "escher-auth": "3.2.4"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+          "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+          "requires": {
+            "follow-redirects": "^1.15.0",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        }
       }
+    },
+    "@emartech/json-logger": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@emartech/json-logger/-/json-logger-7.2.3.tgz",
+      "integrity": "sha512-XLWJmoSy94TJJj86hXondcvtUgcqX+CAI632lYpIVCvF+VYfp4yHAkiew1+T+oHJ/71Pwq2ANpkW7GPereAcBA=="
     },
     "@eslint/eslintrc": {
       "version": "1.3.1",
@@ -8278,6 +8363,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -8346,12 +8432,22 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "axios-retry": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.4.0.tgz",
+      "integrity": "sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "balanced-match": {
@@ -8485,6 +8581,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -8560,6 +8657,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -8567,7 +8665,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -8889,7 +8988,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true
     },
     "escher-auth": {
       "version": "3.2.4",
@@ -8907,16 +9007,6 @@
       "integrity": "sha512-LELndUiissutRRhxkq0PGusxW7IrHtR1H+fZA3cm/VUCawtuQ6XNNF6zfcG8z8tBrVheK8103JrF3qKA2V6h1A==",
       "requires": {
         "logentries-logformat": "0.2.0"
-      }
-    },
-    "escher-suiteapi-js": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/escher-suiteapi-js/-/escher-suiteapi-js-16.2.0.tgz",
-      "integrity": "sha512-ZeljdfkJAX8/GFYAXmlFz7anR0NHKdO792aYbPIhKVEUfMyzwlXhTfhn4iFpWyplF8NbdXlfBehbaGWwaXnEPg==",
-      "requires": {
-        "@emartech/json-logger": "3.5.0",
-        "axios": "0.27.2",
-        "escher-auth": "3.2.4"
       }
     },
     "eslint": {
@@ -9490,7 +9580,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",
@@ -9688,6 +9779,11 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
     },
     "is-stream": {
       "version": "2.0.1",
@@ -12537,6 +12633,11 @@
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -12744,6 +12845,11 @@
       "requires": {
         "esprima": "~4.0.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "regexpp": {
       "version": "3.2.0",
@@ -13158,6 +13264,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   ],
   "homepage": "https://github.com/emartech/suite-js-sdk",
   "dependencies": {
-    "axios": "0.27.2",
+    "@emartech/escher-request": "20.2.1",
+    "axios": "1.6.1",
     "escher-auth": "3.2.4",
     "escher-keypool": "2.0.2",
-    "escher-suiteapi-js": "16.2.0",
     "flat": "5.0.2",
     "lodash": "4.17.21",
     "logentries-logformat": "0.2.0",


### PR DESCRIPTION
In this PR we have updated the `axios` library and replacd the old `escher-suiteapi-js` with the `@emartech/escher-request`.

An important note is that the `escher-suiteapi-js` previously throw `SuiteRequestError` when the request failed but by using the `@emartech/escher-request` the error changed to `EscherRequestError`.

This would have been a breaking change because if someone used this error in an instanceof or created an elastalert rule that depends on the error name, it would not work unless they use the new error name.

To eliminate this breaking change we had to introduce our own `SuiteRequestError` class and catch all `EscherRequestError` from the `@emartech/escher-request` and map it to our own `SuiteRequestError`.