### PR TITLE
use host in request options instead of environment

### DIFF
--- a/lib/api-request/index.js
+++ b/lib/api-request/index.js
@@ -93,7 +93,7 @@ _.extend(ApiRequest.prototype, {
   _getOptions: function(options) {
     options = options || {};
     return {
-      environment: options.environment || this.options.environment,
+      host: options.environment || this.options.environment,
       rejectUnauthorized: _.isUndefined(options.rejectUnauthorized) ? this.options.rejectUnauthorized : options.rejectUnauthorized,
       apiKey: options.apiKey || this.options.apiKey,
       apiSecret: options.apiSecret || this.options.apiSecret,

--- a/lib/api-request/index.spec.js
+++ b/lib/api-request/index.spec.js
@@ -69,7 +69,10 @@ describe('ApiRequest', function() {
 
     it('should use the appropriate keys from the given options object', function(done) {
       var options = getDefaultOptions();
-      var expectedOptions = _.omit(options, 'some_option');
+      var expectedOptions = _.chain(options)
+        .omit(['some_option', 'environment'])
+        .assign({ host: options.environment })
+        .value();
 
       sinon.stub(EscherRequest.prototype, 'get').callsFake(function() {
         return getPromiseResolvesWith({});
@@ -86,7 +89,10 @@ describe('ApiRequest', function() {
 
     it('should use the initial config', function(done) {
       var options = getDefaultOptions();
-      var expectedOptions = _.omit(options, 'some_option');
+      var expectedOptions = _.chain(options)
+        .omit(['some_option', 'environment'])
+        .assign({ host: options.environment })
+        .value();
 
       sinon.stub(EscherRequest.prototype, 'get').callsFake(function() {
         return getPromiseResolvesWith({});
@@ -369,7 +375,10 @@ describe('ApiRequest', function() {
 
     it('should use the appropriate keys from the given options object', function(done) {
       var options = getDefaultOptions();
-      var expectedOptions = _.omit(options, 'some_option');
+      var expectedOptions = _.chain(options)
+        .omit(['some_option', 'environment'])
+        .assign({ host: options.environment })
+        .value();
 
       sinon.stub(EscherRequest.prototype, 'delete').callsFake(function() {
         return getPromiseResolvesWith({});
@@ -426,7 +435,10 @@ describe('ApiRequest', function() {
 
   var testRequestOptionSetupConstructorParameter = function(requestMethod, done) {
     var options = getDefaultOptions();
-    var expectedOptions = _.omit(options, 'some_option');
+    var expectedOptions = _.chain(options)
+      .omit(['some_option', 'environment'])
+      .assign({ host: options.environment })
+      .value();
 
     sinon.stub(EscherRequest.prototype, requestMethod).callsFake(function() {
       return getPromiseResolvesWith({});
@@ -442,7 +454,10 @@ describe('ApiRequest', function() {
 
   var testRequestOptionSetupMethodParameter = function(requestMethod, done) {
     var options = getDefaultOptions();
-    var expectedOptions = _.omit(options, 'some_option');
+    var expectedOptions = _.chain(options)
+      .omit(['some_option', 'environment'])
+      .assign({ host: options.environment })
+      .value();
 
     sinon.stub(EscherRequest.prototype, requestMethod).callsFake(function() {
       return getPromiseResolvesWith({});


### PR DESCRIPTION
The `@emartech/escher-request` package has a hidden breaking change in version 18. Previously, it required an `environment` property in the request options object but in version 18, it changed to `host`.

v17: https://github.com/emartech/escher-suiteapi-js/blob/v17.0.0/lib/requestOption.js#L20
v18: https://github.com/emartech/escher-suiteapi-js/blob/v18.0.0/src/requestOption.ts#L43