### PR TITLE
fix: wrong url of new fetch contactlist endpoint

### DIFF
--- a/api/endpoints/contactlist/index.js
+++ b/api/endpoints/contactlist/index.js
@@ -45,7 +45,7 @@ _.extend(ContactList.prototype, {
       logger.log('contactlist_fetch');
 
       if (payload.next) {
-        var url = util.format('/v2%s', payload.next);
+        var url = payload.next;
         return this._request.get(
           this._getCustomerId(options),
           url,
@@ -53,7 +53,7 @@ _.extend(ContactList.prototype, {
         );
       }
 
-      var url = util.format('/v2/contactlist/%s/contactIds', payload.contact_list_id);
+      var url = util.format('/contactlist/%s/contactIds', payload.contact_list_id);
       return this._request.get(
         this._getCustomerId(options),
         this._buildUrl(url, payload, ['contact_list_id'], false),

--- a/api/endpoints/contactlist/index.spec.js
+++ b/api/endpoints/contactlist/index.spec.js
@@ -32,27 +32,27 @@ describe('SuiteAPI Contact List endpoint', function() {
 
     testApiMethod(ContactListApi, 'fetch').withArgs({
       contact_list_id: 2
-    }).shouldGetResultFromEndpoint('/v2/contactlist/2/contactIds');
+    }).shouldGetResultFromEndpoint('/contactlist/2/contactIds');
 
     testApiMethod(ContactListApi, 'fetch').withArgs({
       contact_list_id: 2,
       next: '/contactlist/2/contactIds?$skiptoken=750&$top=1000'
-    }).shouldGetResultFromEndpoint('/v2/contactlist/2/contactIds?$skiptoken=750&$top=1000');
+    }).shouldGetResultFromEndpoint('/contactlist/2/contactIds?$skiptoken=750&$top=1000');
 
     testApiMethod(ContactListApi, 'fetch').withArgs({
       contact_list_id: 2
-    }).shouldGetResultFromEndpoint('/v2/contactlist/2/contactIds');
+    }).shouldGetResultFromEndpoint('/contactlist/2/contactIds');
 
     testApiMethod(ContactListApi, 'fetch').withArgs({
       contact_list_id: 2,
       $skiptoken: 4
-    }).shouldGetResultFromEndpoint('/v2/contactlist/2/contactIds?$skiptoken=4');
+    }).shouldGetResultFromEndpoint('/contactlist/2/contactIds?$skiptoken=4');
 
     testApiMethod(ContactListApi, 'fetch').withArgs({
       contact_list_id: 2,
       $skiptoken: 4,
       $top: 10000
-    }).shouldGetResultFromEndpoint('/v2/contactlist/2/contactIds?$skiptoken=4&$top=10000');
+    }).shouldGetResultFromEndpoint('/contactlist/2/contactIds?$skiptoken=4&$top=10000');
   });
 
 


### PR DESCRIPTION
I tested it in In-app against Staging using the integration_demo account and some contact list id and discovered that the URL called is wrong (getting a 404):

...../api/v2/internal/218524530/v2/internal/1/contactlist/2/contactIds

and it should be:

/api/v2/internal/1/contactlist/2/contactIds

Basically, I had a mistake in previous PR with adding the prefix _v2_. Deleting it solves the issue and returns the correct result.

### All Submissions:
* [X] Have you followed our guidelines?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New API Endpoints:
* [X] Is it a _public_ API endpoint that you want to implement?
* [X] Did you follow other API endpoint implementations?
* [X] Did you cover it with test(s)?
* [X] Did you document it in the [read me](https://github.com/emartech/suite-js-sdk/blob/master/README.md)?
* [X] Did you link the Emarsys Developer Hub?
