### PR TITLE
SUITEDEV-35218: remove url built using next since next is not correct

### DIFF
--- a/api/endpoints/contactlist/index.js
+++ b/api/endpoints/contactlist/index.js
@@ -44,15 +44,6 @@ _.extend(ContactList.prototype, {
     return this._requireParameters(payload, ['contact_list_id']).then(function() {
       logger.log('contactlist_fetch');
 
-      if (payload.next) {
-        var url = payload.next;
-        return this._request.get(
-          this._getCustomerId(options),
-          url,
-          options
-        );
-      }
-
       var url = util.format('/contactlist/%s/contactIds', payload.contact_list_id);
       return this._request.get(
         this._getCustomerId(options),

--- a/api/endpoints/contactlist/index.spec.js
+++ b/api/endpoints/contactlist/index.spec.js
@@ -35,11 +35,6 @@ describe('SuiteAPI Contact List endpoint', function() {
     }).shouldGetResultFromEndpoint('/contactlist/2/contactIds');
 
     testApiMethod(ContactListApi, 'fetch').withArgs({
-      contact_list_id: 2,
-      next: '/contactlist/2/contactIds?$skiptoken=750&$top=1000'
-    }).shouldGetResultFromEndpoint('/contactlist/2/contactIds?$skiptoken=750&$top=1000');
-
-    testApiMethod(ContactListApi, 'fetch').withArgs({
       contact_list_id: 2
     }).shouldGetResultFromEndpoint('/contactlist/2/contactIds');
 


### PR DESCRIPTION
Unfortunately, the next parameter has to be further processed by deleting the prefix "internal/...". to be actually working.
So, for now, we will delete it and ask the teams using the endpoint in this repo (only Mobile Engage Inapp at the moment) to send as parameters skiptoken and/or top or neither, not next.

### All Submissions:
* [ ] Have you followed our guidelines?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New API Endpoints:
* [X] Is it a _public_ API endpoint that you want to implement?
* [X] Did you follow other API endpoint implementations?
* [X] Did you cover it with test(s)?
* [ ] Did you document it in the [read me](https://github.com/emartech/suite-js-sdk/blob/master/README.md)?
* [ ] Did you link the Emarsys Developer Hub?
