### PR TITLE
fix(auth): use raw body in request authentication

### DIFF
--- a/authentication/request/koa.spec.js
+++ b/authentication/request/koa.spec.js
@@ -14,14 +14,14 @@ describe('Koa Escher Request Authentication Middleware', function() {
 
   var createContext = function(body) {
     return {
-      req: { body: {} },
-      request: { body: body },
+      req: { foo: 'bar', body: {} },
+      request: { rawBody: body },
       throw: sinon.stub()
     };
   };
 
   var createContextWithEmptyBody = function() {
-    return createContext({});
+    return createContext();
   };
 
   beforeEach(function() {
@@ -73,12 +73,13 @@ describe('Koa Escher Request Authentication Middleware', function() {
       expect(escherStub.authenticate).to.have.been.called;
     });
 
-    it('should have been called with original Node request object decorated with the stringified body from the koa\'s request object', async function() {
-      var context = createContext({ testData: 'testValue' });
+    it('should have been called with original Node request object decorated with the raw body from the koa\'s request object', async function() {
+      var rawBody = '{"testData":"testValue"}';
+      var context = createContext(rawBody);
       await callMiddleware(context);
 
-      var expectedRequest = Object.create(context.req);
-      expectedRequest.body = JSON.stringify(context.request.body);
+      var expectedRequest = Object.assign({}, context.req);
+      expectedRequest.body = rawBody;
 
       expect(escherStub.authenticate).to.have.been.calledWithExactly(expectedRequest, sinon.match.any);
     });
@@ -88,8 +89,7 @@ describe('Koa Escher Request Authentication Middleware', function() {
       var context = createContextWithEmptyBody();
       await callMiddleware(context);
 
-      var expectedRequest = Object.create(context.req);
-      expectedRequest.body = context.request.body;
+      var expectedRequest = Object.assign({}, context.req);
 
       expect(escherStub.authenticate).to.have.been.calledWithExactly(expectedRequest, sinon.match.any);
     });

--- a/authentication/request/request-authenticator.js
+++ b/authentication/request/request-authenticator.js
@@ -28,16 +28,11 @@ class RequestAuthenticator {
   _getRequest() {
     var request = this._context.req;
 
-    if (this._hasRequestBody()) {
-      request.body = JSON.stringify(this._context.request.body);
+    if (this._context.request.rawBody) {
+      request.body = this._context.request.rawBody;
     }
 
     return request;
-  }
-
-
-  _hasRequestBody() {
-    return Object.keys(this._context.request.body).length > 0;
   }
 
 


### PR DESCRIPTION
It could happen that the parsed-stringified request body is different from the original raw body breaking the Escher authentication.

SECURITY-10665
