### PR TITLE
chore(ci): fix `release` script name

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:unit": "NODE_ENV=test mocha --reporter spec --ui bdd $(find . -name \"*.spec.js\" -not -path \"./node_modules/*\")",
     "lint": "eslint --fix .",
     "validate-commit-msg": "validate-commit-msg",
-    "semantic-release": "semantic-release",
+    "release": "semantic-release",
     "audit": "better-npm-audit audit"
   },
   "repository": {


### PR DESCRIPTION
Fix #241. Fix #248.

The workflow was copied from a repository that uses `release` as the NPM script name. This repository uses `semantic-release`.
This PR aligns it to use `release` as well.